### PR TITLE
Add constant beeping noise on turn

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ with `nginx`).
 # Development
 
 ```
-cd frontend && yarn build
+cd frontend && yarn watch
 cd backend && cargo run --features dynamic
 ```
 

--- a/frontend/src/Beeper.tsx
+++ b/frontend/src/Beeper.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import beep from './beep';
+
+// Plays a beep sound as long as the component is mounted.
+type Props = {
+  beeper?: () => void;
+  interval?: number;
+};
+
+const defaultBeeper = () => beep(3, 440, 200);
+
+const Beeper = ({beeper = defaultBeeper, interval = 5000}: Props): null => {
+  React.useEffect(() => {
+    beeper();
+    const timer = window.setInterval(beeper, interval);
+    return () => window.clearInterval(timer);
+  });
+
+  return null;
+};
+
+export default Beeper;

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import beep from './beep';
+import Beeper from './Beeper';
 import Errors from './Errors';
 import Trump from './Trump';
 import FriendSelect from './FriendSelect';
@@ -586,9 +586,8 @@ class Play extends React.Component<IPlayProps, IPlayState> {
         }
       }
     });
-    if (this.props.beep_on_turn && is_my_turn && !this.was_my_turn) {
-      beep(3, 440, 200);
-    }
+    const shouldBeBeeping =
+      this.props.beep_on_turn && is_my_turn && !this.was_my_turn;
     this.was_my_turn = is_my_turn;
 
     let remaining_cards_to_play = 0;
@@ -600,6 +599,7 @@ class Play extends React.Component<IPlayProps, IPlayState> {
 
     return (
       <div>
+        {shouldBeBeeping ? <Beeper /> : null}
         <GameMode game_mode={this.props.state.game_mode} />
         <Players
           players={this.props.state.players}


### PR DESCRIPTION
r? @rbtying 

Fixes #5

Updates beeper to be once every five seconds when it's your turn.

Tested by opening four tabs, starting a game:
- check and uncheck the beep checkbox when it's your turn
- start with checkbox checked, make it your turn
- after clicking a card, beeper stops