### PR TITLE
Use context for settings

### DIFF
--- a/frontend/src/Header.tsx
+++ b/frontend/src/Header.tsx
@@ -1,10 +1,9 @@
 import * as React from 'react';
 import GameMode from './GameMode';
 import SettingsButton from './SettingsButton';
-import {SettingsProps} from './SettingsProvider';
 import {IGameMode} from './types';
 
-type Props = SettingsProps & {
+type Props = {
   gameMode: IGameMode;
 };
 
@@ -12,10 +11,7 @@ const Header = (props: Props) => (
   <div>
     <h1>
       <GameMode gameMode={props.gameMode} />
-      <SettingsButton
-        settings={props.settings}
-        onChangeSettings={props.onChangeSettings}
-      />
+      <SettingsButton />
     </h1>
   </div>
 );

--- a/frontend/src/SettingsButton.tsx
+++ b/frontend/src/SettingsButton.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as ReactModal from 'react-modal';
 import Gear from './icons/Gear';
 import SettingsPane from './SettingsPane';
-import {Settings, SettingsProps} from './SettingsProvider';
+import {Settings, SettingsContext} from './SettingsProvider';
 
 const contentStyle = {
   position: 'absolute',
@@ -11,7 +11,7 @@ const contentStyle = {
   transform: 'translate(-50%, -50%)',
 };
 
-const SettingsButton = (props: SettingsProps) => {
+const SettingsButton = () => {
   const [hover, setHover] = React.useState<boolean>(false);
   const [modalOpen, setModalOpen] = React.useState<boolean>(false);
   const fill = hover ? '#444' : '#000';
@@ -35,10 +35,11 @@ const SettingsButton = (props: SettingsProps) => {
         shouldCloseOnEsc
         style={{content: contentStyle}}
       >
-        <SettingsPane
-          settings={props.settings}
-          onChangeSettings={props.onChangeSettings}
-        />
+        <SettingsContext.Consumer>
+          {({settings, updateSettings}) => (
+            <SettingsPane settings={settings} onChange={updateSettings} />
+          )}
+        </SettingsContext.Consumer>
       </ReactModal>
     </a>
   );

--- a/frontend/src/SettingsPane.tsx
+++ b/frontend/src/SettingsPane.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {Settings, SettingsProps} from './SettingsProvider';
+import {Settings} from './SettingsProvider';
 import DivWithProps from './DivWithProps';
 
 const Row = DivWithProps({style: {display: 'table-row'}});
@@ -8,10 +8,14 @@ const LabelCell = DivWithProps({
 });
 const Cell = DivWithProps({style: {display: 'table-cell'}});
 
-const SettingsPane = (props: SettingsProps) => {
+type Props = {
+  settings: Settings;
+  onChange: (settings: Settings) => void;
+};
+const SettingsPane = (props: Props) => {
   const {settings} = props;
   const handleChange = (partialSettings: Partial<Settings>) => () =>
-    props.onChangeSettings({...props.settings, ...partialSettings});
+    props.onChange({...props.settings, ...partialSettings});
 
   return (
     <div className="settings" style={{display: 'table'}}>

--- a/frontend/src/SettingsProvider.tsx
+++ b/frontend/src/SettingsProvider.tsx
@@ -6,24 +6,30 @@ export type Settings = {
   beepOnTurn: boolean;
 };
 
-export type SettingsProps = {
+type ISettingsContext = {
   settings: Settings;
-  onChangeSettings: (settings: Settings) => void;
+  updateSettings: (settings: Settings) => void;
 };
+
+export const SettingsContext = React.createContext<ISettingsContext>({
+  settings: {
+    fourColor: false,
+    showLastTrick: false,
+    beepOnTurn: false,
+  },
+  updateSettings: () => {},
+});
 
 type Props = {
   defaultSettings: Settings;
-  children: (
-    settings: Settings,
-    handleChangeSettings: (settings: Settings) => void,
-  ) => JSX.Element;
+  children: React.ReactNode;
 };
 
 const SettingsProvider = (props: Props) => {
   const [settings, setSettings] = React.useState<Settings>(
     props.defaultSettings,
   );
-  const handleChangeSettings = (newSettings: Settings) => {
+  const updateSettings = (newSettings: Settings) => {
     window.localStorage.setItem(
       'four_color',
       newSettings.fourColor ? 'on' : 'off',
@@ -38,7 +44,11 @@ const SettingsProvider = (props: Props) => {
     );
     setSettings(newSettings);
   };
-  return props.children(settings, handleChangeSettings);
+  return (
+    <SettingsContext.Provider value={{settings, updateSettings}}>
+      {props.children}
+    </SettingsContext.Provider>
+  );
 };
 
 export default SettingsProvider;

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -9,7 +9,7 @@ import Card from './Card';
 import Trick from './Trick';
 import GameMode from './GameMode';
 import Header from './Header';
-import SettingsProvider, {SettingsProps} from './SettingsProvider';
+import SettingsProvider, {SettingsContext} from './SettingsProvider';
 import Credits from './Credits';
 import mapObject from './util/mapObject';
 import {IGameMode, IFriend, ICardInfo, ITrick, ITrump} from './types';
@@ -19,7 +19,7 @@ ReactModal.setAppElement(document.getElementById('root'));
 const CARD_LUT = mapObject(CARDS, (c: ICardInfo) => [c.value, c]);
 (window as any).CARD_LUT = CARD_LUT;
 
-type IInitializeProps = SettingsProps & {
+type IInitializeProps = {
   state: IInitializePhase;
   cards: string[];
   name: string;
@@ -78,11 +78,7 @@ class Initialize extends React.Component<IInitializeProps, {}> {
       this.props.state.game_mode == 'Tractor' ? 'Tractor' : 'FindingFriends';
     return (
       <div>
-        <Header
-          gameMode={this.props.state.game_mode}
-          settings={this.props.settings}
-          onChangeSettings={this.props.onChangeSettings}
-        />
+        <Header gameMode={this.props.state.game_mode} />
         <Players
           players={this.props.state.players}
           landlord={this.props.state.landlord}
@@ -131,7 +127,7 @@ class Initialize extends React.Component<IInitializeProps, {}> {
   }
 }
 
-type IDrawProps = SettingsProps & {
+type IDrawProps = {
   state: IDrawPhase;
   name: string;
   cards: string[];
@@ -276,11 +272,7 @@ class Draw extends React.Component<IDrawProps, IDrawState> {
 
     return (
       <div>
-        <Header
-          gameMode={this.props.state.game_mode}
-          settings={this.props.settings}
-          onChangeSettings={this.props.onChangeSettings}
-        />
+        <Header gameMode={this.props.state.game_mode} />
         <Players
           players={this.props.state.players}
           landlord={this.props.state.landlord}
@@ -350,7 +342,7 @@ class Draw extends React.Component<IDrawProps, IDrawState> {
   }
 }
 
-type IExchangeProps = SettingsProps & {
+type IExchangeProps = {
   state: IExchangePhase;
   name: string;
   cards: string[];
@@ -450,11 +442,7 @@ class Exchange extends React.Component<IExchangeProps, IExchangeState> {
     if (this.props.state.players[landlord_idx].name == this.props.name) {
       return (
         <div>
-          <Header
-            gameMode={this.props.state.game_mode}
-            settings={this.props.settings}
-            onChangeSettings={this.props.onChangeSettings}
-          />
+          <Header gameMode={this.props.state.game_mode} />
           <Players
             players={this.props.state.players}
             landlord={this.props.state.landlord}
@@ -517,11 +505,7 @@ class Exchange extends React.Component<IExchangeProps, IExchangeState> {
     } else {
       return (
         <div>
-          <Header
-            gameMode={this.props.state.game_mode}
-            settings={this.props.settings}
-            onChangeSettings={this.props.onChangeSettings}
-          />
+          <Header gameMode={this.props.state.game_mode} />
           <Players
             players={this.props.state.players}
             landlord={this.props.state.landlord}
@@ -541,7 +525,7 @@ class Exchange extends React.Component<IExchangeProps, IExchangeState> {
   }
 }
 
-type IPlayProps = SettingsProps & {
+type IPlayProps = {
   state: IPlayPhase;
   name: string;
   cards: string[];
@@ -627,11 +611,7 @@ class Play extends React.Component<IPlayProps, IPlayState> {
     return (
       <div>
         {shouldBeBeeping ? <Beeper /> : null}
-        <Header
-          gameMode={this.props.state.game_mode}
-          settings={this.props.settings}
-          onChangeSettings={this.props.onChangeSettings}
-        />
+        <Header gameMode={this.props.state.game_mode} />
         <Players
           players={this.props.state.players}
           landlord={this.props.state.landlord}
@@ -1365,55 +1345,49 @@ function renderUI() {
       };
       ReactDOM.render(
         <SettingsProvider defaultSettings={defaultSettings}>
-          {(settings, handleChangeSettings) => (
-            <div className={state.four_color ? 'four-color' : ''}>
-              <Errors errors={state.errors} />
-              <div className="game">
-                {state.game_state.Initialize ? (
-                  <Initialize
-                    settings={settings}
-                    onChangeSettings={handleChangeSettings}
-                    state={state.game_state.Initialize}
-                    cards={state.cards}
-                    name={state.name}
-                  />
-                ) : null}
-                {state.game_state.Draw ? (
-                  <Draw
-                    settings={settings}
-                    onChangeSettings={handleChangeSettings}
-                    state={state.game_state.Draw}
-                    cards={state.cards}
-                    name={state.name}
-                  />
-                ) : null}
-                {state.game_state.Exchange ? (
-                  <Exchange
-                    settings={settings}
-                    onChangeSettings={handleChangeSettings}
-                    state={state.game_state.Exchange}
-                    cards={state.cards}
-                    name={state.name}
-                  />
-                ) : null}
-                {state.game_state.Play ? (
-                  <Play
-                    settings={settings}
-                    onChangeSettings={handleChangeSettings}
-                    state={state.game_state.Play}
-                    cards={state.cards}
-                    name={state.name}
-                    show_last_trick={state.show_last_trick}
-                    beep_on_turn={state.beep_on_turn}
-                  />
-                ) : null}
-                {state.game_state.Done ? <p>Game Over</p> : null}
+          <SettingsContext.Consumer>
+            {({settings}) => (
+              <div className={settings.fourColor? 'four-color' : ''}>
+                <Errors errors={state.errors} />
+                <div className="game">
+                  {state.game_state.Initialize ? (
+                    <Initialize
+                      state={state.game_state.Initialize}
+                      cards={state.cards}
+                      name={state.name}
+                    />
+                  ) : null}
+                  {state.game_state.Draw ? (
+                    <Draw
+                      state={state.game_state.Draw}
+                      cards={state.cards}
+                      name={state.name}
+                    />
+                  ) : null}
+                  {state.game_state.Exchange ? (
+                    <Exchange
+                      state={state.game_state.Exchange}
+                      cards={state.cards}
+                      name={state.name}
+                    />
+                  ) : null}
+                  {state.game_state.Play ? (
+                    <Play
+                      state={state.game_state.Play}
+                      cards={state.cards}
+                      name={state.name}
+                      show_last_trick={settings.showLastTrick}
+                      beep_on_turn={settings.beepOnTurn}
+                    />
+                  ) : null}
+                  {state.game_state.Done ? <p>Game Over</p> : null}
+                </div>
+                <Chat messages={state.messages} />
+                <hr />
+                <Credits />
               </div>
-              <Chat messages={state.messages} />
-              <hr />
-              <Credits />
-            </div>
-          )}
+            )}
+          </SettingsContext.Consumer>
         </SettingsProvider>,
         document.getElementById('root'),
       );


### PR DESCRIPTION
r? @rbtying 

Instead of passing down `settings` and `onChangeSettings` props all the way down, this uses React.Context to make settings available anywhere in the render tree