### PR TITLE
Migrate state to application state

### DIFF
--- a/frontend/src/AppStateProvider.tsx
+++ b/frontend/src/AppStateProvider.tsx
@@ -5,7 +5,7 @@ import {IGameState} from './types';
 import {State, combineState, noPersistence} from './State';
 import {stringLocalStorageState} from './localStorageState';
 
-type AppState = {
+export type AppState = {
   settings: Settings;
   connected: boolean;
   roomName: string;

--- a/frontend/src/AppStateProvider.tsx
+++ b/frontend/src/AppStateProvider.tsx
@@ -43,7 +43,9 @@ type Props = {
   children: React.ReactNode;
 };
 const AppStateProvider = (props: Props) => {
-  const [state, setState] = React.useState<AppState>(appState.loadDefault());
+  const [state, setState] = React.useState<AppState>(() => {
+    return appState.loadDefault();
+  });
   const updateState = (newState: Partial<AppState>) => {
     const combined = {...state, ...newState};
     appState.persist(state, combined);

--- a/frontend/src/Errors.tsx
+++ b/frontend/src/Errors.tsx
@@ -1,4 +1,6 @@
 import * as React from 'react';
+import {AppStateConsumer} from './AppStateProvider';
+import Timeout from './Timeout';
 
 type Props = {
   errors: string[];
@@ -6,6 +8,11 @@ type Props = {
 
 const Errors = (props: Props) => (
   <div className="errors">
+    <AppStateConsumer>
+      {({updateState}) => (
+        <Timeout timeout={5000} callback={() => updateState({errors: []})} />
+      )}
+    </AppStateConsumer>
     {props.errors.map((err, idx) => (
       <p key={idx}>
         <code>{err}</code>

--- a/frontend/src/Timeout.tsx
+++ b/frontend/src/Timeout.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+
+type Props = {
+  timeout: number;
+  callback: () => void;
+};
+
+const Timeout = (props: Props): null => {
+  React.useEffect(() => {
+    const timeout = setTimeout(props.callback, props.timeout);
+    return () => clearTimeout(timeout);
+  });
+  return null;
+};
+
+export default Timeout;

--- a/frontend/src/WebsocketProvider.tsx
+++ b/frontend/src/WebsocketProvider.tsx
@@ -1,0 +1,63 @@
+import * as React from 'react';
+import {AppState, AppStateConsumer} from './AppStateProvider';
+import websocketHandler from './websocketHandler';
+
+type Context = {
+  send: (value: any) => void;
+};
+
+const WebsocketContext = React.createContext<Context>({
+  send: () => {},
+});
+
+export const WebsocketConsumer = WebsocketContext.Consumer;
+
+type Props = {
+  state: AppState;
+  updateState: (state: Partial<AppState>) => void;
+  children?: React.ReactNode;
+};
+const WebsocketProvider = (props: Props) => {
+  const {state, updateState, children} = props;
+  const [websocket, setWebsocket] = React.useState<WebSocket | null>(null);
+
+  React.useEffect(() => {
+    const uri =
+      (location.protocol === 'https:' ? 'wss://' : 'ws://') +
+      location.host +
+      location.pathname +
+      (location.pathname.endsWith('/') ? 'api' : '/api');
+
+    const ws = new WebSocket(uri);
+    setWebsocket(ws);
+
+    ws.addEventListener('open', () => updateState({connected: true}));
+    ws.addEventListener('close', () => updateState({connected: false}));
+    ws.addEventListener('message', (event: MessageEvent) => {
+      const message = JSON.parse(event.data);
+      if (message === 'Kicked') {
+        ws.close();
+      } else {
+        updateState(websocketHandler(state, message));
+      }
+    });
+  }, []);
+
+  const send = (value: any) => websocket?.send(JSON.stringify(value));
+
+  return (
+    <WebsocketContext.Provider value={{send}}>
+      {children}
+    </WebsocketContext.Provider>
+  );
+};
+
+export default () => {
+  return (
+    <AppStateConsumer>
+      {({state, updateState}) => (
+        <WebsocketProvider state={state} updateState={updateState} />
+      )}
+    </AppStateConsumer>
+  );
+};

--- a/frontend/src/WebsocketProvider.tsx
+++ b/frontend/src/WebsocketProvider.tsx
@@ -21,6 +21,19 @@ const WebsocketProvider = (props: Props) => {
   const {state, updateState, children} = props;
   const [websocket, setWebsocket] = React.useState<WebSocket | null>(null);
 
+  // Because state/updateState are passed in and change every time something
+  // happens, we need to maintain a reference to these props to prevent stale
+  // closures which may happen if state/updateState is changed between when an
+  // event listener is registered and when it fires.
+  // https://reactjs.org/docs/hooks-faq.html#why-am-i-seeing-stale-props-or-state-inside-my-function
+  const stateRef = React.useRef(state);
+  const updateStateRef = React.useRef(updateState);
+
+  React.useEffect(() => {
+    stateRef.current = state;
+    updateStateRef.current = updateState;
+  }, [state, updateState]);
+
   React.useEffect(() => {
     const uri =
       (location.protocol === 'https:' ? 'wss://' : 'ws://') +
@@ -31,19 +44,26 @@ const WebsocketProvider = (props: Props) => {
     const ws = new WebSocket(uri);
     setWebsocket(ws);
 
-    ws.addEventListener('open', () => updateState({connected: true}));
-    ws.addEventListener('close', () => updateState({connected: false}));
+    ws.addEventListener('open', () =>
+      updateStateRef.current({connected: true}),
+    );
+    ws.addEventListener('close', () =>
+      updateStateRef.current({connected: false}),
+    );
     ws.addEventListener('message', (event: MessageEvent) => {
       const message = JSON.parse(event.data);
       if (message === 'Kicked') {
         ws.close();
       } else {
-        updateState(websocketHandler(state, message));
+        console.log(websocketHandler(stateRef.current, message));
+        updateStateRef.current(websocketHandler(stateRef.current, message));
       }
     });
   }, []);
 
   const send = (value: any) => websocket?.send(JSON.stringify(value));
+  // TODO(read this from consumers instead of globals)
+  (window as any).send = send;
 
   return (
     <WebsocketContext.Provider value={{send}}>

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -10,6 +10,7 @@ import Card from './Card';
 import Trick from './Trick';
 import Header from './Header';
 import AppStateProvider, {AppStateConsumer} from './AppStateProvider';
+import WebsocketProvider from './WebsocketProvider';
 import Credits from './Credits';
 import Chat from './Chat';
 import mapObject from './util/mapObject';
@@ -1238,6 +1239,7 @@ function renderUI() {
     if (state.game_state === null) {
       ReactDOM.render(
         <AppStateProvider>
+          <WebsocketProvider />
           <AppStateConsumer>
             {({state: appState, updateState}) => (
               <div>
@@ -1265,6 +1267,7 @@ function renderUI() {
     } else {
       ReactDOM.render(
         <AppStateProvider>
+          <WebsocketProvider />
           <AppStateConsumer>
             {({state: appState, updateState}) => {
               const {settings} = appState;

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1215,7 +1215,6 @@ interface State {
   connected: boolean;
   game_state: IGameState | null;
   cards: string[];
-  errors: string[];
   messages: {from: string; message: string; from_game: boolean}[];
 }
 
@@ -1223,7 +1222,6 @@ const state: State = {
   connected: false,
   game_state: null,
   cards: [],
-  errors: [],
   messages: [],
 };
 
@@ -1250,7 +1248,7 @@ function renderUI() {
                   </a>
                   )
                 </h2>
-                <Errors errors={state.errors} />
+                <Errors errors={appState.errors} />
                 <JoinRoom
                   name={appState.name}
                   room_name={appState.roomName}
@@ -1273,7 +1271,7 @@ function renderUI() {
               const {settings} = appState;
               return (
                 <div className={settings.fourColor ? 'four-color' : ''}>
-                  <Errors errors={state.errors} />
+                  <Errors errors={appState.errors} />
                   <div className="game">
                     {state.game_state.Initialize ? null : (
                       <a
@@ -1370,14 +1368,6 @@ ws.onmessage = (event) => {
     if (state.messages.length >= 100) {
       state.messages.shift();
     }
-  }
-
-  if (msg.Error) {
-    state.errors.push(msg.Error);
-    setTimeout(() => {
-      state.errors = state.errors.filter((v) => v !== msg.Error);
-      renderUI();
-    }, 5000);
   }
 
   if (msg.State) {

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1214,14 +1214,12 @@ const ws = new WebSocket(uri);
 interface State {
   connected: boolean;
   game_state: IGameState | null;
-  cards: string[];
   messages: {from: string; message: string; from_game: boolean}[];
 }
 
 const state: State = {
   connected: false,
   game_state: null,
-  cards: [],
   messages: [],
 };
 
@@ -1295,28 +1293,28 @@ function renderUI() {
                     {state.game_state.Initialize ? (
                       <Initialize
                         state={state.game_state.Initialize}
-                        cards={state.cards}
+                        cards={appState.cards}
                         name={appState.name}
                       />
                     ) : null}
                     {state.game_state.Draw ? (
                       <Draw
                         state={state.game_state.Draw}
-                        cards={state.cards}
+                        cards={appState.cards}
                         name={appState.name}
                       />
                     ) : null}
                     {state.game_state.Exchange ? (
                       <Exchange
                         state={state.game_state.Exchange}
-                        cards={state.cards}
+                        cards={appState.cards}
                         name={appState.name}
                       />
                     ) : null}
                     {state.game_state.Play ? (
                       <Play
                         state={state.game_state.Play}
-                        cards={state.cards}
+                        cards={appState.cards}
                         name={appState.name}
                         show_last_trick={settings.showLastTrick}
                         beep_on_turn={settings.beepOnTurn}
@@ -1368,11 +1366,6 @@ ws.onmessage = (event) => {
     if (state.messages.length >= 100) {
       state.messages.shift();
     }
-  }
-
-  if (msg.State) {
-    state.game_state = msg.State.state;
-    state.cards = msg.State.cards;
   }
 
   if (msg === 'Kicked') {

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -9,7 +9,7 @@ import LabeledPlay from './LabeledPlay';
 import Card from './Card';
 import Trick from './Trick';
 import Header from './Header';
-import AppStateProvider, {AppStateConsumer} from './AppStateProvider';
+import AppStateProvider, {AppState, AppStateConsumer} from './AppStateProvider';
 import WebsocketProvider from './WebsocketProvider';
 import Credits from './Credits';
 import Chat from './Chat';
@@ -20,7 +20,6 @@ import {
   IExchangePhase,
   IFriend,
   IGameMode,
-  IGameState,
   IInitializePhase,
   IPlayPhase,
   IPlayer,
@@ -1204,175 +1203,105 @@ if (window.location.hash.length !== 17) {
   window.location.hash = r;
 }
 
-const uri =
-  (location.protocol === 'https:' ? 'wss://' : 'ws://') +
-  location.host +
-  location.pathname +
-  (location.pathname.endsWith('/') ? 'api' : '/api');
-const ws = new WebSocket(uri);
-
-interface State {
-  connected: boolean;
-  game_state: IGameState | null;
-  messages: {from: string; message: string; from_game: boolean}[];
-}
-
-const state: State = {
-  connected: false,
-  game_state: null,
-  messages: [],
-};
-
-(window as any).state = state;
-(window as any).send = send;
-
-function send(value: any) {
-  ws.send(JSON.stringify(value));
-}
-
-function renderUI() {
+const renderUI = (props: {
+  state: AppState;
+  updateState: (state: Partial<AppState>) => void;
+}) => {
+  const {state, updateState} = props;
   if (state.connected) {
     if (state.game_state === null) {
-      ReactDOM.render(
-        <AppStateProvider>
-          <WebsocketProvider />
-          <AppStateConsumer>
-            {({state: appState, updateState}) => (
-              <div>
-                <h2>
-                  Room Name: {appState.roomName} (
-                  <a href="rules" target="_blank">
-                    rules
-                  </a>
-                  )
-                </h2>
-                <Errors errors={appState.errors} />
-                <JoinRoom
-                  name={appState.name}
-                  room_name={appState.roomName}
-                  setName={(name: string) => updateState({name})}
-                />
-                <hr />
-                <Credits />
-              </div>
-            )}
-          </AppStateConsumer>
-        </AppStateProvider>,
-        document.getElementById('root'),
+      return (
+        <div>
+          <h2>
+            Room Name: {state.roomName} (
+            <a href="rules" target="_blank">
+              rules
+            </a>
+            )
+          </h2>
+          <Errors errors={state.errors} />
+          <JoinRoom
+            name={state.name}
+            room_name={state.roomName}
+            setName={(name: string) => updateState({name})}
+          />
+          <hr />
+          <Credits />
+        </div>
       );
     } else {
-      ReactDOM.render(
-        <AppStateProvider>
-          <WebsocketProvider />
-          <AppStateConsumer>
-            {({state: appState, updateState}) => {
-              const {settings} = appState;
-              return (
-                <div className={settings.fourColor ? 'four-color' : ''}>
-                  <Errors errors={appState.errors} />
-                  <div className="game">
-                    {state.game_state.Initialize ? null : (
-                      <a
-                        href={window.location.href}
-                        className="reset-link"
-                        onClick={(evt) => {
-                          evt.preventDefault();
-                          if (
-                            window.confirm(
-                              'Do you really want to reset the game?',
-                            )
-                          ) {
-                            send({Action: 'ResetGame'});
-                          }
-                          renderUI();
-                        }}
-                      >
-                        Reset game
-                      </a>
-                    )}
-                    {state.game_state.Initialize ? (
-                      <Initialize
-                        state={state.game_state.Initialize}
-                        cards={appState.cards}
-                        name={appState.name}
-                      />
-                    ) : null}
-                    {state.game_state.Draw ? (
-                      <Draw
-                        state={state.game_state.Draw}
-                        cards={appState.cards}
-                        name={appState.name}
-                      />
-                    ) : null}
-                    {state.game_state.Exchange ? (
-                      <Exchange
-                        state={state.game_state.Exchange}
-                        cards={appState.cards}
-                        name={appState.name}
-                      />
-                    ) : null}
-                    {state.game_state.Play ? (
-                      <Play
-                        state={state.game_state.Play}
-                        cards={appState.cards}
-                        name={appState.name}
-                        show_last_trick={settings.showLastTrick}
-                        beep_on_turn={settings.beepOnTurn}
-                      />
-                    ) : null}
-                    {state.game_state.Done ? <p>Game Over</p> : null}
-                  </div>
-                  <Chat messages={state.messages} />
-                  <hr />
-                  <Credits />
-                </div>
-              );
-            }}
-          </AppStateConsumer>
-        </AppStateProvider>,
-        document.getElementById('root'),
+      return (
+        <div className={state.settings.fourColor ? 'four-color' : ''}>
+          <Errors errors={state.errors} />
+          <div className="game">
+            {state.game_state.Initialize ? null : (
+              <a
+                href={window.location.href}
+                className="reset-link"
+                onClick={(evt) => {
+                  evt.preventDefault();
+                  if (window.confirm('Do you really want to reset the game?')) {
+                    send({Action: 'ResetGame'});
+                  }
+                }}
+              >
+                Reset game
+              </a>
+            )}
+            {state.game_state.Initialize ? (
+              <Initialize
+                state={state.game_state.Initialize}
+                cards={state.cards}
+                name={state.name}
+              />
+            ) : null}
+            {state.game_state.Draw ? (
+              <Draw
+                state={state.game_state.Draw}
+                cards={state.cards}
+                name={state.name}
+              />
+            ) : null}
+            {state.game_state.Exchange ? (
+              <Exchange
+                state={state.game_state.Exchange}
+                cards={state.cards}
+                name={state.name}
+              />
+            ) : null}
+            {state.game_state.Play ? (
+              <Play
+                state={state.game_state.Play}
+                cards={state.cards}
+                name={state.name}
+                show_last_trick={state.settings.showLastTrick}
+                beep_on_turn={state.settings.beepOnTurn}
+              />
+            ) : null}
+            {state.game_state.Done ? <p>Game Over</p> : null}
+          </div>
+          <Chat messages={state.messages} />
+          <hr />
+          <Credits />
+        </div>
       );
     }
   } else {
-    ReactDOM.render(
-      <p>disconnected from server, please refresh</p>,
-      document.getElementById('root'),
-    );
+    return <p>disconnected from server, please refresh</p>;
   }
-}
-
-ws.onopen = () => {
-  state.connected = true;
-  renderUI();
 };
-ws.onclose = (evt) => {
-  state.connected = false;
-  renderUI();
-};
-ws.onmessage = (event) => {
-  const msg = JSON.parse(event.data);
-  if (msg.Message) {
-    state.messages.push(msg.Message);
-    if (state.messages.length >= 100) {
-      state.messages.shift();
-    }
-  }
-  if (msg.Broadcast) {
-    state.messages.push({
-      from: 'GAME',
-      message: msg.Broadcast,
-      from_game: true,
-    });
-    if (state.messages.length >= 100) {
-      state.messages.shift();
-    }
-  }
 
-  if (msg === 'Kicked') {
-    ws.close();
-  }
-
-  renderUI();
+const bootstrap = () => {
+  ReactDOM.render(
+    <AppStateProvider>
+      <WebsocketProvider />
+      <AppStateConsumer>{renderUI}</AppStateConsumer>
+    </AppStateProvider>,
+    document.getElementById('root'),
+  );
 };
+
+bootstrap();
 
 declare var CARDS: ICardInfo[];
+declare var send: (value: any) => void;

--- a/frontend/src/localStorageState.ts
+++ b/frontend/src/localStorageState.ts
@@ -7,7 +7,9 @@ export const localStorageState = <T>(
 ): State<T> => {
   return {
     loadDefault: () => extractor(window.localStorage.getItem(key)),
-    persist: (t: T) => window.localStorage.setItem(key, serializer(t)),
+    persist: (before: T, after: T) => {
+      window.localStorage.setItem(key, serializer(after));
+    },
   };
 };
 

--- a/frontend/src/websocketHandler.ts
+++ b/frontend/src/websocketHandler.ts
@@ -45,7 +45,7 @@ const errorHandler: WebsocketHandler = (state: AppState, message: any) => {
 
 const stateHandler: WebsocketHandler = (state: AppState, message: any) => {
   if (message.State) {
-    return {game_state: message.State.state, cards: message.State.crds};
+    return {game_state: message.State.state, cards: message.State.cards};
   } else {
     return null;
   }
@@ -57,7 +57,7 @@ const compose = (
 ): WebsocketHandler => {
   return (state: AppState, message: any) => {
     const newState = {...state, ...left(state, message)};
-    return right(newState, message);
+    return {...newState, ...right(newState, message)};
   };
 };
 

--- a/frontend/src/websocketHandler.ts
+++ b/frontend/src/websocketHandler.ts
@@ -1,0 +1,71 @@
+import {AppState} from './AppStateProvider';
+
+const truncate = (length: number) => <T>(array: T[]): T[] => {
+  if (array.length > length) {
+    return array.slice(array.length - length);
+  } else {
+    return array;
+  }
+};
+const truncateMessages = truncate(100);
+
+type WebsocketHandler = (
+  state: AppState,
+  message: any,
+) => Partial<AppState> | null;
+
+const messageHandler: WebsocketHandler = (state: AppState, message: any) => {
+  if (message.Message) {
+    return {messages: truncateMessages([...state.messages, message.Message])};
+  } else {
+    return null;
+  }
+};
+
+const broadcastHandler: WebsocketHandler = (state: AppState, message: any) => {
+  if (message.Broadcast) {
+    const newMessage = {
+      from: 'GAME',
+      message: message.Broadcast,
+      from_game: true,
+    };
+    return {messages: truncateMessages([...state.messages, newMessage])};
+  } else {
+    return null;
+  }
+};
+
+const errorHandler: WebsocketHandler = (state: AppState, message: any) => {
+  if (message.Error) {
+    return {errors: [...state.errors, message.Error]};
+  } else {
+    return null;
+  }
+};
+
+const stateHandler: WebsocketHandler = (state: AppState, message: any) => {
+  if (message.State) {
+    return {game_state: message.State.state, cards: message.State.crds};
+  } else {
+    return null;
+  }
+};
+
+const compose = (
+  left: WebsocketHandler,
+  right: WebsocketHandler,
+): WebsocketHandler => {
+  return (state: AppState, message: any) => {
+    const newState = {...state, ...left(state, message)};
+    return right(newState, message);
+  };
+};
+
+const allHandlers: WebsocketHandler[] = [
+  messageHandler,
+  broadcastHandler,
+  errorHandler,
+  stateHandler,
+];
+
+export default allHandlers.reduce(compose) as WebsocketHandler;


### PR DESCRIPTION
Moves all websocket-initiated state to AppState

- changed the behavior of errors -- instead of removing individual error messages, all disappear at the same time after 5000ms of no new errors
- Added WebsocketProvider, which does two things:
  - Sets up connection to websocket, binds listeners to it, and updates AppState as needed
  - Creates a `send` and allows users to read from it. Nobody does this yet; it's just set as a global
- Removed all ReactDOM.render except 1, put it into a bootstrap() function