### PR TITLE
Use a WebWorker for timers rather than the `window` ones

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -170,6 +170,12 @@ async fn main() {
             .header("Content-Type", "text/css; charset=utf-8")
             .body(CSS)
     });
+    #[cfg(not(feature = "dynamic"))]
+    let worker_js = warp::path("timer-worker.js").map(|| {
+        warp::http::Response::builder()
+            .header("Content-Type", "text/javascript; charset=utf-8")
+            .body(WORKER_JS)
+    });
 
     #[cfg(feature = "dynamic")]
     let index = warp::path::end().and(warp::fs::file("../frontend/static/index.html"));
@@ -181,6 +187,9 @@ async fn main() {
     let js_map = warp::path("main.js.map").and(warp::fs::file("../frontend/dist/main.js.map"));
     #[cfg(feature = "dynamic")]
     let css = warp::path("style.css").and(warp::fs::file("../frontend/static/style.css"));
+    #[cfg(feature = "dynamic")]
+    let worker_js =
+        warp::path("timer-worker.js").and(warp::fs::file("../frontend/static/timer-worker.js"));
 
     let cards = warp::path("cards.js").map(|| {
         warp::http::Response::builder()
@@ -197,6 +206,7 @@ async fn main() {
     let routes = index
         .or(js)
         .or(js_map)
+        .or(worker_js)
         .or(css)
         .or(cards)
         .or(api)
@@ -463,3 +473,5 @@ static JS: &str = include_str!("../../frontend/dist/main.js");
 static JS_MAP: &str = include_str!("../../frontend/dist/main.js.map");
 #[cfg(not(feature = "dynamic"))]
 static CSS: &str = include_str!("../../frontend/static/style.css");
+#[cfg(not(feature = "dynamic"))]
+static WORKER_JS: &str = include_str!("../../frontend/static/timer-worker.js");

--- a/frontend/src/Beeper.tsx
+++ b/frontend/src/Beeper.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import beep from './beep';
+import {TimerConsumer} from './TimerProvider';
 
 // Plays a beep sound as long as the component is mounted.
 type Props = {
@@ -7,16 +8,41 @@ type Props = {
   interval?: number;
 };
 
+type InnerProps = {
+  beeper: () => void;
+  interval: number;
+  setInterval: (fn: () => void, interval: number) => number;
+  clearInterval: (id: number) => void;
+};
+
 const defaultBeeper = () => beep(3, 440, 200);
 
-const Beeper = ({beeper = defaultBeeper, interval = 5000}: Props): null => {
+const _Beeper = ({
+  beeper,
+  interval,
+  setInterval,
+  clearInterval,
+}: InnerProps): null => {
   React.useEffect(() => {
     beeper();
-    const timer = window.setInterval(beeper, interval);
-    return () => window.clearInterval(timer);
-  });
+    const timer = setInterval(beeper, interval);
+    return () => clearInterval(timer);
+  }, []);
 
   return null;
 };
+
+const Beeper = ({beeper = defaultBeeper, interval = 5000}: Props) => (
+  <TimerConsumer>
+    {({setInterval, clearInterval}) => (
+      <_Beeper
+        beeper={beeper}
+        interval={interval}
+        setInterval={setInterval}
+        clearInterval={clearInterval}
+      />
+    )}
+  </TimerConsumer>
+);
 
 export default Beeper;

--- a/frontend/src/Timeout.tsx
+++ b/frontend/src/Timeout.tsx
@@ -1,16 +1,37 @@
 import * as React from 'react';
+import {TimerConsumer} from './TimerProvider';
+
+type InnerProps = {
+  timeout: number;
+  callback: () => void;
+  setTimeout: (fn: () => void, timeout: number) => number;
+  clearTimeout: (id: number) => void;
+};
+
+const _Timeout = (props: InnerProps): null => {
+  React.useEffect(() => {
+    const timeout = props.setTimeout(props.callback, props.timeout);
+    return () => props.clearTimeout(timeout);
+  });
+  return null;
+};
 
 type Props = {
   timeout: number;
   callback: () => void;
 };
 
-const Timeout = (props: Props): null => {
-  React.useEffect(() => {
-    const timeout = setTimeout(props.callback, props.timeout);
-    return () => clearTimeout(timeout);
-  });
-  return null;
-};
+const Timeout = (props: Props) => (
+  <TimerConsumer>
+    {({setTimeout, clearTimeout}) => (
+      <_Timeout
+        timeout={props.timeout}
+        callback={props.callback}
+        setTimeout={setTimeout}
+        clearTimeout={clearTimeout}
+      />
+    )}
+  </TimerConsumer>
+);
 
 export default Timeout;

--- a/frontend/src/TimerProvider.tsx
+++ b/frontend/src/TimerProvider.tsx
@@ -1,0 +1,81 @@
+import * as React from 'react';
+
+type Context = {
+  setTimeout: (fn: () => void, delay: number) => number;
+  clearTimeout: (id: number) => void;
+  setInterval: (fn: () => void, interval: number) => number;
+  clearInterval: (id: number) => void;
+};
+
+const TimerContext = React.createContext<Context>({
+  setTimeout: (fn, delay) => 0,
+  clearTimeout: (id) => {},
+  setInterval: (fn, interval) => 0,
+  clearInterval: (id) => {},
+});
+
+export const TimerConsumer = TimerContext.Consumer;
+
+const _TimerProvider: React.FunctionComponent<{}> = (props) => {
+  const [worker, setWorker] = React.useState<Worker | null>(null);
+  const timeoutId = React.useRef(0);
+  const callbacks = React.useRef<{[id: number]: () => void}>({});
+
+  React.useEffect(() => {
+    const timerWorker = new Worker('timer-worker.js');
+
+    timerWorker.addEventListener('message', (evt) => {
+      const data = evt.data;
+      const id = data.id as number;
+      if (callbacks.current[id]) {
+        callbacks.current[id]();
+      }
+      if (data.variant === 'timeout') {
+        delete callbacks.current[id];
+      }
+    });
+    setWorker(timerWorker);
+  }, []);
+
+  const setTimeout = (fn: () => void, delay: number) => {
+    timeoutId.current += 1;
+    delay = delay || 0;
+    const id = timeoutId.current;
+    callbacks.current[id] = fn;
+    worker.postMessage({command: 'setTimeout', id, timeout: delay});
+    return id;
+  };
+
+  const clearTimeout = (id: number) => {
+    worker.postMessage({command: 'clearTimeout', id});
+    delete callbacks.current[id];
+  };
+
+  const setInterval = (fn: () => void, interval: number) => {
+    timeoutId.current += 1;
+    interval = interval || 0;
+    const id = timeoutId.current;
+    callbacks.current[id] = fn;
+    worker.postMessage({command: 'setInterval', id, interval});
+    return id;
+  };
+
+  const clearInterval = (id: number) => {
+    worker.postMessage({command: 'clearInterval', id});
+    delete callbacks.current[id];
+  };
+
+  return (
+    <TimerContext.Provider
+      value={{setTimeout, clearTimeout, setInterval, clearInterval}}
+    >
+      {props.children}
+    </TimerContext.Provider>
+  );
+};
+
+const TimerProvider: React.FunctionComponent<{}> = (props) => (
+  <_TimerProvider>{props.children}</_TimerProvider>
+);
+
+export default TimerProvider;

--- a/frontend/static/timer-worker.js
+++ b/frontend/static/timer-worker.js
@@ -1,0 +1,40 @@
+const timers = {};
+
+function fireTimeout(id) {
+  this.postMessage({id: id, variant: 'timeout'});
+  delete timers[id];
+}
+
+function fireInterval(id) {
+  this.postMessage({id: id, variant: 'interval'});
+}
+
+this.addEventListener('message', function(evt) {
+  const data = evt.data;
+  switch (data.command) {
+    case 'setTimeout':
+      const time = parseInt(data.timeout || 0, 10);
+      const timer = setTimeout(fireTimeout.bind(null, data.id), time);
+      timers[data.id] = timer;
+      break;
+    case 'setInterval':
+      const interval = parseInt(data.interval || 0, 10);
+      const handle = setInterval(fireInterval.bind(null, data.id), interval);
+      timers[data.id] = handle;
+      break;
+    case 'clearTimeout':
+      const clearTimeoutHandle = timers[data.id];
+      if (clearTimeoutHandle) {
+        clearTimeout(clearTimeoutHandle);
+      }
+      delete timers[data.id];
+      break;
+    case 'clearInterval':
+      const clearIntervalHandle = timers[data.id];
+      if (clearIntervalHandle) {
+        clearInterval(clearIntervalHandle);
+      }
+      delete timers[data.id];
+      break;
+  }
+});


### PR DESCRIPTION
This is mostly helpful for development: setTimeout / setInterval events
on tabs which are not in focus are constrained to fire at most once per
second, which makes the deal unbearably slow. However, WebWorkers are
not limited in this way, so we can use the worker's timer to implement
the frontend's timer.

This will probably make testing #8 easier.