### PR TITLE
Use InlineCard for bids

### DIFF
--- a/frontend/src/ChatMessage.tsx
+++ b/frontend/src/ChatMessage.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import {IGameMode} from './types';
 import InlineCard from './InlineCard';
 import classNames from 'classnames';
+import ArrayUtil from './util/array';
 
 type MessageVariant =
   | {type: 'GameModeSet'; game_mode: IGameMode}
@@ -39,22 +40,27 @@ export type Message = {
 
 const renderMessage = (message: Message) => {
   const variant = message.data?.variant;
-  switch (variant.type) {
+  switch (variant?.type) {
+    case 'MadeBid':
+      return (
+        <span>
+          {message.data.actor_name} bid{' '}
+          {ArrayUtil.range(variant.count, (i) => (
+            <InlineCard card={variant.card} key={i} />
+          ))}
+        </span>
+      );
     case 'PlayedCards':
       const cards = variant.cards.map((card, i) => (
         <InlineCard card={card} key={i} />
       ));
       return (
         <span>
-          {message.from}: {message.data.actor_name} played {cards}
+          {message.data.actor_name} played {cards}
         </span>
       );
     default:
-      return (
-        <span>
-          {message.from}: {message.message}
-        </span>
-      );
+      return <span>{message.message}</span>;
   }
 };
 
@@ -65,6 +71,7 @@ const ChatMessage = (props: Props) => {
   const {message} = props;
   return (
     <p className={classNames('message', {'game-message': message.from_game})}>
+      <span>{message.from}: </span>
       {renderMessage(message)}
     </p>
   );


### PR DESCRIPTION
r? @rbtying 

Use InlineCard in the bid log message.

Also fix a nil check on `variant.type`

<img width="154" alt="Screen Shot 2020-04-12 at 9 51 20 PM" src="https://user-images.githubusercontent.com/935063/79085802-d204e280-7d07-11ea-9f5c-410709885241.png">

I changed it to print multiple copies of the card, rather than a number in front because it looked weird when the numbers were the same:
<img width="140" alt="Screen Shot 2020-04-12 at 9 49 49 PM" src="https://user-images.githubusercontent.com/935063/79085816-e0eb9500-7d07-11ea-8930-cd9a4ec4e4f1.png">
