### PR TITLE
Add option to protect longer tuples from shorter tuples

### DIFF
--- a/core/src/interactive.rs
+++ b/core/src/interactive.rs
@@ -4,7 +4,7 @@ use slog::{debug, info, o, Logger};
 
 use crate::game_state::{
     AdvancementPolicy, Friend, GameModeSettings, GameState, InitializePhase, KittyBidPolicy,
-    KittyPenalty, ThrowPenalty,
+    KittyPenalty, ThrowPenalty, TrickDrawPolicy,
 };
 use crate::message::MessageVariant;
 use crate::types::{Card, Number, PlayerID};
@@ -135,6 +135,10 @@ impl InteractiveGame {
                 info!(logger, "Setting kitty bid policy"; "bid_policy" => format!("{:?}", kitty_bid_policy));
                 state.set_kitty_bid_policy(kitty_bid_policy)?
             }
+            (Message::SetTrickDrawPolicy(policy), GameState::Initialize(ref mut state)) => {
+                info!(logger, "Setting trick draw policy"; "draw_policy" => format!("{:?}", policy));
+                state.set_trick_draw_policy(policy)?
+            }
             (Message::SetAdvancementPolicy(policy), GameState::Initialize(ref mut state)) => {
                 info!(logger, "Setting advancement policy"; "policy" => format!("{:?}", policy));
                 state.set_advancement_policy(policy)?
@@ -253,6 +257,7 @@ pub enum Message {
     SetAdvancementPolicy(AdvancementPolicy),
     SetKittyPenalty(KittyPenalty),
     SetKittyBidPolicy(KittyBidPolicy),
+    SetTrickDrawPolicy(TrickDrawPolicy),
     SetThrowPenalty(ThrowPenalty),
     StartGame,
     DrawCard,
@@ -331,6 +336,9 @@ impl BroadcastMessage {
             ThrowPenaltySet { throw_penalty: ThrowPenalty::TenPointsPerAttempt } => format!("{} set the throw penalty to 10 points per throw", n?),
             KittyBidPolicySet { policy: KittyBidPolicy::FirstCard } => format!("{} set the bid-from-bottom policy to be the first card revealed", n?),
             KittyBidPolicySet { policy: KittyBidPolicy::FirstCardOfLevelOrHighest } => format!("{} set the bid-from-bottom policy to be the first card of the appropriate level, or the highest if none are found", n?),
+            TrickDrawPolicySet { policy: TrickDrawPolicy::NoProtections } => format!("{} removed long-tuple protections (pair can draw triple)", n?),
+            TrickDrawPolicySet { policy: TrickDrawPolicy::LongerTuplesProtected } => format!("{}
+                protected longer tuples from being drawn out by shorter ones (pair does not draw triple)", n?),
             RevealedCardFromKitty => format!("{} revealed a card from the bottom of the deck", n?),
         })
     }

--- a/core/src/message.rs
+++ b/core/src/message.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::game_state::{
     AdvancementPolicy, GameModeSettings, KittyBidPolicy, KittyPenalty, ThrowPenalty,
+    TrickDrawPolicy,
 };
 use crate::types::{Card, Number, PlayerID};
 
@@ -86,6 +87,9 @@ pub enum MessageVariant {
     },
     KittyBidPolicySet {
         policy: KittyBidPolicy,
+    },
+    TrickDrawPolicySet {
+        policy: TrickDrawPolicy,
     },
     RevealedCardFromKitty,
 }

--- a/frontend/src/Credits.tsx
+++ b/frontend/src/Credits.tsx
@@ -29,6 +29,13 @@ const ChangeLog = () => {
         style={{content: contentStyle}}
       >
         <h2>Change Log</h2>
+        <p>5/13/2020:</p>
+        <ul>
+          <li>
+            Add an option to protect triples from being drawn out by pairs
+          </li>
+          <li>Fill in the suit character in the trump UI</li>
+        </ul>
         <p>5/8/2020:</p>
         <ul>
           <li>

--- a/frontend/src/Initialize.tsx
+++ b/frontend/src/Initialize.tsx
@@ -107,6 +107,17 @@ const Initialize = (props: Props) => {
     }
   };
 
+  const setTrickDrawPolicy = (evt: any) => {
+    evt.preventDefault();
+    if (evt.target.value !== '') {
+      send({
+        Action: {
+          SetTrickDrawPolicy: evt.target.value,
+        },
+      });
+    }
+  };
+
   const setAdvancementPolicy = (evt: any) => {
     evt.preventDefault();
     if (evt.target.value !== '') {
@@ -356,6 +367,20 @@ const Initialize = (props: Props) => {
               <option value="None">No penalty</option>
               <option value="TenPointsPerAttempt">
                 Ten points per bad throw
+              </option>
+            </select>
+          </label>
+        </div>
+        <div>
+          <label>
+            Card protection policy:{' '}
+            <select
+              value={props.state.propagated.trick_draw_policy}
+              onChange={setTrickDrawPolicy}
+            >
+              <option value="NoProtections">No protections</option>
+              <option value="LongerTuplesProtected">
+                Longer tuple (triple) is protected from shorter (pair)
               </option>
             </select>
           </label>

--- a/frontend/src/Trump.tsx
+++ b/frontend/src/Trump.tsx
@@ -1,14 +1,19 @@
 import * as React from 'react';
 import {ITrump} from './types';
+import InlineCard from './InlineCard';
+import preloadedCards from './preloadedCards';
 
 type Props = {trump: ITrump};
 const Trump = (props: Props) => {
   const {trump} = props;
   if (trump.Standard) {
     const {suit, number: rank} = trump.Standard;
+    const card = preloadedCards.filter(
+      (v) => v.typ === suit && v.number === rank,
+    )[0].value;
     return (
       <div className="trump">
-        The trump suit is <span className={suit}>{suit}</span>, rank {rank}
+        The trump suit is <InlineCard card={card} /> (rank {rank})
       </div>
     );
   } else {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -75,6 +75,7 @@ export interface IPropagatedState {
   kitty_penalty: 'Times' | 'Power';
   kitty_bid_policy: 'FirstCard' | 'FirstCardOfLevelOrHighest';
   throw_penalty: 'None' | 'TenPointsPerAttempt';
+  trick_draw_policy: 'NoProtections' | 'LongerTuplesProtected';
   hide_played_cards: boolean;
 }
 


### PR DESCRIPTION
Fixes #56. As implemented, 6677 tractor will not draw out JJJ. This
makes the reasoning a little more consistent, though conflicts are
hopefully sufficiently infrequent to not care.