### PR TITLE
Add statistics tracking across games in localstorage.

### DIFF
--- a/core/src/game_state.rs
+++ b/core/src/game_state.rs
@@ -925,12 +925,15 @@ impl PlayPhase {
                 });
             }
 
-            game_result.insert(player.name.to_string(), PlayerResult {
-                won_game: landlord_won == self.landlords_team.contains(&player.id),
-                is_defending: is_defending,
-                is_landlord: self.landlord == player.id,
-                ranks_up: num_advances,
-            });
+            game_result.insert(
+                player.name.to_string(),
+                PlayerResult {
+                    won_game: landlord_won == self.landlords_team.contains(&player.id),
+                    is_defending,
+                    is_landlord: self.landlord == player.id,
+                    ranks_up: num_advances,
+                },
+            );
         }
 
         msgs.push(MessageVariant::GameFinished {

--- a/core/src/game_state.rs
+++ b/core/src/game_state.rs
@@ -9,7 +9,7 @@ use url::Url;
 use crate::hands::Hands;
 use crate::message::MessageVariant;
 use crate::trick::{Trick, TrickEnded};
-use crate::types::{Card, Number, PlayerID, PlayerResult, Trump, FULL_DECK};
+use crate::types::{Card, Number, PlayerID, Trump, FULL_DECK};
 
 macro_rules! bail_unwrap {
     ($opt:expr) => {
@@ -666,6 +666,14 @@ impl Deref for GameState {
     }
 }
 
+#[derive(Debug, Copy, Clone, Serialize, Deserialize, Hash, Eq, PartialEq)]
+pub struct PlayerGameFinishedResult {
+    pub won_game: bool,
+    pub is_defending: bool,
+    pub is_landlord: bool,
+    pub ranks_up: usize,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PlayPhase {
     num_decks: usize,
@@ -927,8 +935,8 @@ impl PlayPhase {
 
             game_result.insert(
                 player.name.to_string(),
-                PlayerResult {
-                    won_game: landlord_won == self.landlords_team.contains(&player.id),
+                PlayerGameFinishedResult {
+                    won_game: landlord_won == is_defending,
                     is_defending,
                     is_landlord: self.landlord == player.id,
                     ranks_up: num_advances,

--- a/core/src/interactive.rs
+++ b/core/src/interactive.rs
@@ -340,6 +340,7 @@ impl BroadcastMessage {
             TrickDrawPolicySet { policy: TrickDrawPolicy::LongerTuplesProtected } => format!("{}
                 protected longer tuples from being drawn out by shorter ones (pair does not draw triple)", n?),
             RevealedCardFromKitty => format!("{} revealed a card from the bottom of the deck", n?),
+            GameFinished { result: _ } => "The game has finished.".to_string()
         })
     }
 }

--- a/core/src/message.rs
+++ b/core/src/message.rs
@@ -1,10 +1,12 @@
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
 
 use crate::game_state::{
     AdvancementPolicy, GameModeSettings, KittyBidPolicy, KittyPenalty, ThrowPenalty,
     TrickDrawPolicy,
 };
-use crate::types::{Card, Number, PlayerID};
+use crate::types::{Card, Number, PlayerID, PlayerResult};
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(tag = "type")]
@@ -92,4 +94,7 @@ pub enum MessageVariant {
         policy: TrickDrawPolicy,
     },
     RevealedCardFromKitty,
+    GameFinished {
+        result: HashMap<String, PlayerResult>
+    },
 }

--- a/core/src/message.rs
+++ b/core/src/message.rs
@@ -95,6 +95,6 @@ pub enum MessageVariant {
     },
     RevealedCardFromKitty,
     GameFinished {
-        result: HashMap<String, PlayerResult>
+        result: HashMap<String, PlayerResult>,
     },
 }

--- a/core/src/message.rs
+++ b/core/src/message.rs
@@ -3,10 +3,10 @@ use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 
 use crate::game_state::{
-    AdvancementPolicy, GameModeSettings, KittyBidPolicy, KittyPenalty, ThrowPenalty,
-    TrickDrawPolicy,
+    AdvancementPolicy, GameModeSettings, KittyBidPolicy, KittyPenalty, PlayerGameFinishedResult,
+    ThrowPenalty, TrickDrawPolicy,
 };
-use crate::types::{Card, Number, PlayerID, PlayerResult};
+use crate::types::{Card, Number, PlayerID};
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(tag = "type")]
@@ -95,6 +95,6 @@ pub enum MessageVariant {
     },
     RevealedCardFromKitty,
     GameFinished {
-        result: HashMap<String, PlayerResult>,
+        result: HashMap<String, PlayerGameFinishedResult>,
     },
 }

--- a/core/src/types.rs
+++ b/core/src/types.rs
@@ -11,14 +11,6 @@ use smallvec::{smallvec, SmallVec};
 pub struct PlayerID(pub usize);
 
 #[derive(Debug, Copy, Clone, Serialize, Deserialize, Hash, Eq, PartialEq)]
-pub struct PlayerResult {
-    pub won_game: bool,
-    pub is_defending: bool,
-    pub is_landlord: bool,
-    pub ranks_up: usize,
-}
-
-#[derive(Debug, Copy, Clone, Serialize, Deserialize, Hash, Eq, PartialEq)]
 pub enum Trump {
     Standard { suit: Suit, number: Number },
     NoTrump { number: Number },

--- a/core/src/types.rs
+++ b/core/src/types.rs
@@ -11,6 +11,14 @@ use smallvec::{smallvec, SmallVec};
 pub struct PlayerID(pub usize);
 
 #[derive(Debug, Copy, Clone, Serialize, Deserialize, Hash, Eq, PartialEq)]
+pub struct PlayerResult {
+    pub won_game: bool,
+    pub is_defending: bool,
+    pub is_landlord: bool,
+    pub ranks_up: usize
+}
+
+#[derive(Debug, Copy, Clone, Serialize, Deserialize, Hash, Eq, PartialEq)]
 pub enum Trump {
     Standard { suit: Suit, number: Number },
     NoTrump { number: Number },

--- a/core/src/types.rs
+++ b/core/src/types.rs
@@ -15,7 +15,7 @@ pub struct PlayerResult {
     pub won_game: bool,
     pub is_defending: bool,
     pub is_landlord: bool,
-    pub ranks_up: usize
+    pub ranks_up: usize,
 }
 
 #[derive(Debug, Copy, Clone, Serialize, Deserialize, Hash, Eq, PartialEq)]

--- a/frontend/src/AppStateProvider.tsx
+++ b/frontend/src/AppStateProvider.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import {Message} from './ChatMessage';
-import gameStatistics, {GameStatistics} from './state/GameStatistics'
+import gameStatistics, {GameStatistics} from './state/GameStatistics';
 import settings, {Settings} from './state/Settings';
 import {IGameState} from './types';
 import {State, combineState, noPersistence} from './State';
@@ -8,7 +8,7 @@ import {stringLocalStorageState} from './localStorageState';
 
 export type AppState = {
   settings: Settings;
-  gameStatistics: GameStatistics,
+  gameStatistics: GameStatistics;
   connected: boolean;
   roomName: string;
   name: string;

--- a/frontend/src/AppStateProvider.tsx
+++ b/frontend/src/AppStateProvider.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import {Message} from './ChatMessage';
+import gameStatistics, {GameStatistics} from './state/GameStatistics'
 import settings, {Settings} from './state/Settings';
 import {IGameState} from './types';
 import {State, combineState, noPersistence} from './State';
@@ -7,6 +8,7 @@ import {stringLocalStorageState} from './localStorageState';
 
 export type AppState = {
   settings: Settings;
+  gameStatistics: GameStatistics,
   connected: boolean;
   roomName: string;
   name: string;
@@ -18,6 +20,7 @@ export type AppState = {
 
 const appState: State<AppState> = combineState({
   settings,
+  gameStatistics,
   connected: noPersistence(() => false),
   roomName: noPersistence(() => window.location.hash.slice(1)),
   name: stringLocalStorageState('name'),

--- a/frontend/src/GameStatisticsButton.tsx
+++ b/frontend/src/GameStatisticsButton.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react';
+import * as ReactModal from 'react-modal';
+import IconButton from './IconButton';
+import BarChart from './icons/BarChart';
+import GameStatisticsPane from './GameStatisticsPane';
+import {AppStateContext} from './AppStateProvider';
+
+const contentStyle = {
+  position: 'absolute',
+  top: '50%',
+  left: '50%',
+  transform: 'translate(-50%, -50%)',
+};
+
+const GameStatisticsButton = () => {
+  const [modalOpen, setModalOpen] = React.useState<boolean>(false);
+  const {state} = React.useContext(AppStateContext);
+  return (
+    <>
+      <IconButton style={{paddingLeft: "10px"}} onClick={() => setModalOpen(true)}>
+        <BarChart width="2em" />
+      </IconButton>
+      <ReactModal
+        isOpen={modalOpen}
+        onRequestClose={() => setModalOpen(false)}
+        shouldCloseOnOverlayClick
+        shouldCloseOnEsc
+        style={{content: contentStyle}}
+      >
+        <GameStatisticsPane
+          gameStatistics={state.gameStatistics}
+        />
+      </ReactModal>
+    </>
+  );
+};
+
+export default GameStatisticsButton;

--- a/frontend/src/GameStatisticsButton.tsx
+++ b/frontend/src/GameStatisticsButton.tsx
@@ -17,7 +17,10 @@ const GameStatisticsButton = () => {
   const {state} = React.useContext(AppStateContext);
   return (
     <>
-      <IconButton style={{paddingLeft: "10px"}} onClick={() => setModalOpen(true)}>
+      <IconButton
+        style={{paddingLeft: '10px'}}
+        onClick={() => setModalOpen(true)}
+      >
         <BarChart width="2em" />
       </IconButton>
       <ReactModal
@@ -27,9 +30,7 @@ const GameStatisticsButton = () => {
         shouldCloseOnEsc
         style={{content: contentStyle}}
       >
-        <GameStatisticsPane
-          gameStatistics={state.gameStatistics}
-        />
+        <GameStatisticsPane gameStatistics={state.gameStatistics} />
       </ReactModal>
     </>
   );

--- a/frontend/src/GameStatisticsPane.tsx
+++ b/frontend/src/GameStatisticsPane.tsx
@@ -24,7 +24,7 @@ const percentage = (numerator: number, denominator: number) => {
   return 'n/a';
 }
 
-const ranks = (ranks: number, numGames: number) => {
+const ranksPerGame = (ranks: number, numGames: number) => {
   if (numGames > 0) {
     return (ranks/numGames).toFixed(3);
   }
@@ -55,7 +55,6 @@ type Props = {
 
 const GameStatisticsPane = (props: Props) => {
   const {gameStatistics} = props;
-  console.log(gameStatistics);
 
   const gamesPlayedAsAttacking = gameStatistics.gamesPlayed - gameStatistics.gamesPlayedAsDefending;
   const gamesWonAsAttacking = gameStatistics.gamesWon - gameStatistics.gamesWonAsDefending;
@@ -70,22 +69,22 @@ const GameStatisticsPane = (props: Props) => {
           <LabelCell>won</LabelCell>
           <LabelCell>percentage</LabelCell>
         </Row>
-        <GameStatisticsRow 
+        <GameStatisticsRow
           label={'attacking'}
           numPlayed={gamesPlayedAsAttacking}
           numWon={gamesWonAsAttacking}
         />
-        <GameStatisticsRow 
+        <GameStatisticsRow
           label={'defending'}
           numPlayed={gameStatistics.gamesPlayedAsDefending}
           numWon={gameStatistics.gamesWonAsDefending}
         />
-        <GameStatisticsRow 
+        <GameStatisticsRow
           label={'as landlord'}
           numPlayed={gameStatistics.gamesPlayedAsLandlord}
           numWon={gameStatistics.gamesWonAsLandlord}
         />
-        <GameStatisticsRow 
+        <GameStatisticsRow
           label={'total'}
           numPlayed={gameStatistics.gamesPlayed}
           numWon={gameStatistics.gamesWon}
@@ -95,11 +94,11 @@ const GameStatisticsPane = (props: Props) => {
       <div style={{display: 'table'}}>
         <Row>
           <LabelCell>ranks/game</LabelCell>
-          <Cell>{ranks(gameStatistics.ranksUp, gameStatistics.gamesPlayed)}</Cell>
+          <Cell>{ranksPerGame(gameStatistics.ranksUp, gameStatistics.gamesPlayed)}</Cell>
         </Row>
         <Row>
           <LabelCell>ranks/win</LabelCell>
-          <Cell>{ranks(gameStatistics.ranksUp, gameStatistics.gamesWon)}</Cell>
+          <Cell>{ranksPerGame(gameStatistics.ranksUp, gameStatistics.gamesWon)}</Cell>
         </Row>
       </div>
     </div>

--- a/frontend/src/GameStatisticsPane.tsx
+++ b/frontend/src/GameStatisticsPane.tsx
@@ -1,0 +1,109 @@
+import * as React from 'react';
+import {GameStatistics} from './state/GameStatistics';
+import styled from 'styled-components';
+
+const Row = styled.div`
+  display: table-row;
+  line-height: 23px;
+`;
+const LabelCell = styled.div`
+  display: table-cell;
+  padding-right: 2em;
+  font-weight: bold;
+`;
+const Cell = styled.div`
+  display: table-cell;
+`;
+
+
+
+const percentage = (numerator: number, denominator: number) => {
+  if (denominator > 0) {
+    return (numerator/denominator * 100).toFixed(2)+'%';
+  }
+  return 'n/a';
+}
+
+const ranks = (ranks: number, numGames: number) => {
+  if (numGames > 0) {
+    return (ranks/numGames).toFixed(3);
+  }
+  return 'n/a';
+}
+
+type RowProps = {
+  label: string;
+  numPlayed: number;
+  numWon: number;
+}
+
+const GameStatisticsRow = ({label, numPlayed, numWon}: RowProps) => {
+  return (
+    <Row>
+      <LabelCell>{label}</LabelCell>
+      <Cell>{numPlayed}</Cell>
+      <Cell>{numWon}</Cell>
+      <Cell>{percentage(numWon, numPlayed)}</Cell>
+    </Row>
+  )
+}
+
+
+type Props = {
+  gameStatistics: GameStatistics;
+};
+
+const GameStatisticsPane = (props: Props) => {
+  const {gameStatistics} = props;
+  console.log(gameStatistics);
+
+  const gamesPlayedAsAttacking = gameStatistics.gamesPlayed - gameStatistics.gamesPlayedAsDefending;
+  const gamesWonAsAttacking = gameStatistics.gamesWon - gameStatistics.gamesWonAsDefending;
+
+  return (
+    <div className="gameStatistics">
+      <h3>win statistics</h3>
+      <div style={{display: 'table'}}>
+        <Row>
+          <Cell/>
+          <LabelCell>played</LabelCell>
+          <LabelCell>won</LabelCell>
+          <LabelCell>percentage</LabelCell>
+        </Row>
+        <GameStatisticsRow 
+          label={'attacking'}
+          numPlayed={gamesPlayedAsAttacking}
+          numWon={gamesWonAsAttacking}
+        />
+        <GameStatisticsRow 
+          label={'defending'}
+          numPlayed={gameStatistics.gamesPlayedAsDefending}
+          numWon={gameStatistics.gamesWonAsDefending}
+        />
+        <GameStatisticsRow 
+          label={'as landlord'}
+          numPlayed={gameStatistics.gamesPlayedAsLandlord}
+          numWon={gameStatistics.gamesWonAsLandlord}
+        />
+        <GameStatisticsRow 
+          label={'total'}
+          numPlayed={gameStatistics.gamesPlayed}
+          numWon={gameStatistics.gamesWon}
+        />
+      </div>
+      <h3>rank up statistics</h3>
+      <div style={{display: 'table'}}>
+        <Row>
+          <LabelCell>ranks/game</LabelCell>
+          <Cell>{ranks(gameStatistics.ranksUp, gameStatistics.gamesPlayed)}</Cell>
+        </Row>
+        <Row>
+          <LabelCell>ranks/win</LabelCell>
+          <Cell>{ranks(gameStatistics.ranksUp, gameStatistics.gamesWon)}</Cell>
+        </Row>
+      </div>
+    </div>
+  );
+};
+
+export default GameStatisticsPane;

--- a/frontend/src/GameStatisticsPane.tsx
+++ b/frontend/src/GameStatisticsPane.tsx
@@ -15,27 +15,25 @@ const Cell = styled.div`
   display: table-cell;
 `;
 
-
-
 const percentage = (numerator: number, denominator: number) => {
   if (denominator > 0) {
-    return (numerator/denominator * 100).toFixed(2)+'%';
+    return ((numerator / denominator) * 100).toFixed(2) + '%';
   }
   return 'n/a';
-}
+};
 
 const ranksPerGame = (ranks: number, numGames: number) => {
   if (numGames > 0) {
-    return (ranks/numGames).toFixed(3);
+    return (ranks / numGames).toFixed(3);
   }
   return 'n/a';
-}
+};
 
 type RowProps = {
   label: string;
   numPlayed: number;
   numWon: number;
-}
+};
 
 const GameStatisticsRow = ({label, numPlayed, numWon}: RowProps) => {
   return (
@@ -45,9 +43,8 @@ const GameStatisticsRow = ({label, numPlayed, numWon}: RowProps) => {
       <Cell>{numWon}</Cell>
       <Cell>{percentage(numWon, numPlayed)}</Cell>
     </Row>
-  )
-}
-
+  );
+};
 
 type Props = {
   gameStatistics: GameStatistics;
@@ -56,15 +53,17 @@ type Props = {
 const GameStatisticsPane = (props: Props) => {
   const {gameStatistics} = props;
 
-  const gamesPlayedAsAttacking = gameStatistics.gamesPlayed - gameStatistics.gamesPlayedAsDefending;
-  const gamesWonAsAttacking = gameStatistics.gamesWon - gameStatistics.gamesWonAsDefending;
+  const gamesPlayedAsAttacking =
+    gameStatistics.gamesPlayed - gameStatistics.gamesPlayedAsDefending;
+  const gamesWonAsAttacking =
+    gameStatistics.gamesWon - gameStatistics.gamesWonAsDefending;
 
   return (
     <div className="gameStatistics">
       <h3>win statistics</h3>
       <div style={{display: 'table'}}>
         <Row>
-          <Cell/>
+          <Cell />
           <LabelCell>played</LabelCell>
           <LabelCell>won</LabelCell>
           <LabelCell>percentage</LabelCell>
@@ -94,11 +93,15 @@ const GameStatisticsPane = (props: Props) => {
       <div style={{display: 'table'}}>
         <Row>
           <LabelCell>ranks/game</LabelCell>
-          <Cell>{ranksPerGame(gameStatistics.ranksUp, gameStatistics.gamesPlayed)}</Cell>
+          <Cell>
+            {ranksPerGame(gameStatistics.ranksUp, gameStatistics.gamesPlayed)}
+          </Cell>
         </Row>
         <Row>
           <LabelCell>ranks/win</LabelCell>
-          <Cell>{ranksPerGame(gameStatistics.ranksUp, gameStatistics.gamesWon)}</Cell>
+          <Cell>
+            {ranksPerGame(gameStatistics.ranksUp, gameStatistics.gamesWon)}
+          </Cell>
         </Row>
       </div>
     </div>

--- a/frontend/src/Header.tsx
+++ b/frontend/src/Header.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import GameMode from './GameMode';
+import GameStatisticsButton from './GameStatisticsButton';
 import SettingsButton from './SettingsButton';
 import {IGameModeSettings} from './types';
 
@@ -14,6 +15,7 @@ const Header = (props: Props) => (
       <GameMode gameMode={props.gameMode} />
       &nbsp;
       <SettingsButton />
+      <GameStatisticsButton />
     </h1>
     {props.chatLink ? (
       <p>

--- a/frontend/src/icons/BarChart.tsx
+++ b/frontend/src/icons/BarChart.tsx
@@ -12,9 +12,9 @@ const BarChart = ({width = '100%'}: Props) => (
     fill="currentColor"
     width={width}
   >
-    <rect width="4" height="5" x="1" y="10" rx="1"/>
-    <rect width="4" height="9" x="6" y="6" rx="1"/>
-    <rect width="4" height="14" x="11" y="1" rx="1"/>
+    <rect width="4" height="5" x="1" y="10" rx="1" />
+    <rect width="4" height="9" x="6" y="6" rx="1" />
+    <rect width="4" height="14" x="11" y="1" rx="1" />
   </svg>
 );
 

--- a/frontend/src/icons/BarChart.tsx
+++ b/frontend/src/icons/BarChart.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+
+type Props = {
+  width?: string;
+};
+const BarChart = ({width = '100%'}: Props) => (
+  <svg
+    focusable="false"
+    role="img"
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 16 16"
+    fill="currentColor"
+    width={width}
+  >
+    <rect width="4" height="5" x="1" y="10" rx="1"/>
+    <rect width="4" height="9" x="6" y="6" rx="1"/>
+    <rect width="4" height="14" x="11" y="1" rx="1"/>
+  </svg>
+);
+
+export default BarChart;

--- a/frontend/src/localStorageState.ts
+++ b/frontend/src/localStorageState.ts
@@ -32,3 +32,13 @@ export const stringLocalStorageState = (
     (value: any): string => (typeof value === 'string' ? value : defaultValue),
     (state: string) => state,
   );
+
+export const numberLocalStorageState = (
+  key: string,
+  defaultValue = 0,
+): State<number> =>
+  localStorageState(
+    key,
+    (value: any): number => (value != null && !isNaN(value) ? parseInt(value) : defaultValue),
+    (state: number) => state,
+  );

--- a/frontend/src/localStorageState.ts
+++ b/frontend/src/localStorageState.ts
@@ -39,6 +39,6 @@ export const numberLocalStorageState = (
 ): State<number> =>
   localStorageState(
     key,
-    (value: any): number => (value != null && !isNaN(value) ? parseInt(value) : defaultValue),
+    (value: any): number => (value != null && !isNaN(value) ? parseInt(value, 10) : defaultValue),
     (state: number) => state,
   );

--- a/frontend/src/localStorageState.ts
+++ b/frontend/src/localStorageState.ts
@@ -39,6 +39,7 @@ export const numberLocalStorageState = (
 ): State<number> =>
   localStorageState(
     key,
-    (value: any): number => (value != null && !isNaN(value) ? parseInt(value, 10) : defaultValue),
+    (value: any): number =>
+      value != null && !isNaN(value) ? parseInt(value, 10) : defaultValue,
     (state: number) => state,
   );

--- a/frontend/src/state/GameStatistics.ts
+++ b/frontend/src/state/GameStatistics.ts
@@ -2,21 +2,29 @@ import {State, combineState} from '../State';
 import {numberLocalStorageState} from '../localStorageState';
 
 export type GameStatistics = {
-  gamesPlayed: number,
-  gamesPlayedAsDefending: number,
-  gamesPlayedAsLandlord: number,
-  gamesWon: number,
-  gamesWonAsDefending: number,
-  gamesWonAsLandlord: number,
-  ranksUp: number
+  gamesPlayed: number;
+  gamesPlayedAsDefending: number;
+  gamesPlayedAsLandlord: number;
+  gamesWon: number;
+  gamesWonAsDefending: number;
+  gamesWonAsLandlord: number;
+  ranksUp: number;
 };
 
 const gamesPlayed: State<number> = numberLocalStorageState('games_played');
-const gamesPlayedAsDefending: State<number> = numberLocalStorageState('games_played_as_defending');
-const gamesPlayedAsLandlord: State<number> = numberLocalStorageState('games_played_as_landlord');
+const gamesPlayedAsDefending: State<number> = numberLocalStorageState(
+  'games_played_as_defending',
+);
+const gamesPlayedAsLandlord: State<number> = numberLocalStorageState(
+  'games_played_as_landlord',
+);
 const gamesWon: State<number> = numberLocalStorageState('games_won');
-const gamesWonAsDefending: State<number> = numberLocalStorageState('games_won_as_defending');
-const gamesWonAsLandlord: State<number> = numberLocalStorageState('games_won_as_landlord');
+const gamesWonAsDefending: State<number> = numberLocalStorageState(
+  'games_won_as_defending',
+);
+const gamesWonAsLandlord: State<number> = numberLocalStorageState(
+  'games_won_as_landlord',
+);
 const ranksUp: State<number> = numberLocalStorageState('ranks_up');
 
 const gameStatistics: State<GameStatistics> = combineState({

--- a/frontend/src/state/GameStatistics.ts
+++ b/frontend/src/state/GameStatistics.ts
@@ -1,0 +1,32 @@
+import {State, combineState} from '../State';
+import {numberLocalStorageState} from '../localStorageState';
+
+export type GameStatistics = {
+  gamesPlayed: number,
+  gamesPlayedAsDefending: number,
+  gamesPlayedAsLandlord: number,
+  gamesWon: number,
+  gamesWonAsDefending: number,
+  gamesWonAsLandlord: number,
+  ranksUp: number
+};
+
+const gamesPlayed: State<number> = numberLocalStorageState('games_played');
+const gamesPlayedAsDefending: State<number> = numberLocalStorageState('games_played_as_defending');
+const gamesPlayedAsLandlord: State<number> = numberLocalStorageState('games_played_as_landlord');
+const gamesWon: State<number> = numberLocalStorageState('games_won');
+const gamesWonAsDefending: State<number> = numberLocalStorageState('games_won_as_defending');
+const gamesWonAsLandlord: State<number> = numberLocalStorageState('games_won_as_landlord');
+const ranksUp: State<number> = numberLocalStorageState('ranks_up');
+
+const gameStatistics: State<GameStatistics> = combineState({
+  gamesPlayed,
+  gamesPlayedAsDefending,
+  gamesPlayedAsLandlord,
+  gamesWon,
+  gamesWonAsDefending,
+  gamesWonAsLandlord,
+  ranksUp,
+});
+
+export default gameStatistics;

--- a/frontend/src/websocketHandler.ts
+++ b/frontend/src/websocketHandler.ts
@@ -66,12 +66,44 @@ const beepHandler: WebsocketHandler = (state: AppState, message: any) => {
   return null;
 };
 
+const gameFinishedHandler: WebsocketHandler = (state: AppState, message: any) => {
+  if (message.Broadcast && message.Broadcast.data.variant.type === 'GameFinished') {
+    const ownResult = message.Broadcast.data.variant.result[state.name];
+    const gameStatistics = state.gameStatistics;
+
+    const newGameStatistics = {...gameStatistics};
+    newGameStatistics.gamesPlayed++;
+    if (ownResult.is_defending) {
+      newGameStatistics.gamesPlayedAsDefending++;
+      if (ownResult.is_landlord) {
+        newGameStatistics.gamesPlayedAsLandlord++;
+      }
+    }
+
+    if (ownResult.won_game) {
+      newGameStatistics.gamesWon++;
+      if (ownResult.is_defending) {
+        newGameStatistics.gamesWonAsDefending++;
+        if (ownResult.is_landlord) {
+          newGameStatistics.gamesWonAsLandlord++;
+        }
+      }
+    }
+
+    newGameStatistics.ranksUp += ownResult.ranks_up;
+    return {gameStatistics: newGameStatistics};
+  }
+  return null;
+}
+
+
 const allHandlers: WebsocketHandler[] = [
   messageHandler,
   broadcastHandler,
   errorHandler,
   stateHandler,
   beepHandler,
+  gameFinishedHandler,
 ];
 
 const composedHandlers: WebsocketHandler = (state: AppState, message: any) => {

--- a/frontend/src/websocketHandler.ts
+++ b/frontend/src/websocketHandler.ts
@@ -66,8 +66,14 @@ const beepHandler: WebsocketHandler = (state: AppState, message: any) => {
   return null;
 };
 
-const gameFinishedHandler: WebsocketHandler = (state: AppState, message: any) => {
-  if (message.Broadcast && message.Broadcast.data.variant.type === 'GameFinished') {
+const gameFinishedHandler: WebsocketHandler = (
+  state: AppState,
+  message: any,
+) => {
+  if (
+    message.Broadcast &&
+    message.Broadcast.data.variant.type === 'GameFinished'
+  ) {
     const ownResult = message.Broadcast.data.variant.result[state.name];
     const gameStatistics = state.gameStatistics;
 
@@ -94,8 +100,7 @@ const gameFinishedHandler: WebsocketHandler = (state: AppState, message: any) =>
     return {gameStatistics: newGameStatistics};
   }
   return null;
-}
-
+};
 
 const allHandlers: WebsocketHandler[] = [
   messageHandler,


### PR DESCRIPTION
Adds functionality to stores game statistics in local storage and adds a component to display statistics.

I added a `GameFinished` message that sends the relevant metadata to the frontend and then the `gameFinishedHandler` figures out what to do to manipulate local storage.

I kind of cargo culted what was going on with the `Settings` for the display part 😇

![Screen Shot 2020-05-23 at 8 39 03 PM](https://user-images.githubusercontent.com/5981363/82745123-7598d800-9d35-11ea-8005-67e692539fe6.png)

![Screen Shot 2020-05-23 at 8 15 39 PM](https://user-images.githubusercontent.com/5981363/82745139-b55fbf80-9d35-11ea-8235-7535d64d32f1.png)


(edge case, no games yet)
![Screen Shot 2020-05-23 at 8 29 45 PM](https://user-images.githubusercontent.com/5981363/82744980-2c945400-9d34-11ea-97d9-cc87037a98b7.png)

