### PR TITLE
#133 - update landlord bg color, and make the trick list carry all th…

### DIFF
--- a/frontend/src/Credits.tsx
+++ b/frontend/src/Credits.tsx
@@ -29,6 +29,18 @@ const ChangeLog = () => {
         style={{ content: contentStyle }}
       >
         <h2>Change Log</h2>
+        <p>6/13/2020:</p>
+        <ul>
+          <li>
+            (#133)  Improve trick list to show landlord, player self, better coloring of team and winning trick.
+          </li>
+        </ul>
+        <p>6/12/2020:</p>
+        <ul>
+          <li>
+            (#131)  Add option to disallow using highest non-trump card to select friend.
+          </li>
+        </ul>
         <p>6/7/2020:</p>
         <ul>
           <li>

--- a/frontend/src/Credits.tsx
+++ b/frontend/src/Credits.tsx
@@ -32,7 +32,7 @@ const ChangeLog = () => {
         <p>6/13/2020:</p>
         <ul>
           <li>
-            (#133)  Improve trick list to show landlord, player self, better coloring of team and winning trick.
+            (#133)  Improve trick list to show landlord, better coloring of team and winning trick.
           </li>
         </ul>
         <p>6/12/2020:</p>

--- a/frontend/src/LabeledPlay.tsx
+++ b/frontend/src/LabeledPlay.tsx
@@ -3,7 +3,7 @@ import classNames from 'classnames';
 import Card from './Card';
 
 type Props = {
-  id: number;
+  id?: number | null;
   className?: string;
   cards: string[];
   moreCards?: string[];

--- a/frontend/src/LabeledPlay.tsx
+++ b/frontend/src/LabeledPlay.tsx
@@ -3,12 +3,18 @@ import classNames from 'classnames';
 import Card from './Card';
 
 type Props = {
+  id: number;
   className?: string;
   cards: string[];
   moreCards?: string[];
   label: string;
+  next?: number | null;
 };
 const LabeledPlay = (props: Props) => {
+  const className = classNames('label', {
+    next: props.id === props.next,
+  });
+
   return (
     <div className={classNames('labeled-play', props.className)}>
       <div className="play">
@@ -23,7 +29,7 @@ const LabeledPlay = (props: Props) => {
           ))}
         </div>
       ) : null}
-      <div className="label">{props.label}</div>
+      <div className={className}>{props.label}</div>
     </div>
   );
 };

--- a/frontend/src/Play.tsx
+++ b/frontend/src/Play.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {IPlayPhase} from './types';
+import { IPlayPhase } from './types';
 import Header from './Header';
 import Beeper from './Beeper';
 import Trump from './Trump';
@@ -12,7 +12,7 @@ import Players from './Players';
 import ArrayUtils from './util/array';
 import AutoPlayButton from './AutoPlayButton';
 import BeepButton from './BeepButton';
-import {WebsocketContext} from './WebsocketProvider';
+import { WebsocketContext } from './WebsocketProvider';
 
 type Props = {
   playPhase: IPlayPhase;
@@ -25,20 +25,20 @@ type Props = {
 };
 
 const Play = (props: Props) => {
-  const {send} = React.useContext(WebsocketContext);
+  const { send } = React.useContext(WebsocketContext);
   const [selected, setSelected] = React.useState<string[]>([]);
 
   const playCards = () => {
-    send({Action: {PlayCards: selected}});
+    send({ Action: { PlayCards: selected } });
     setSelected([]);
   };
 
   const sendEvent = (event: {}) => () => send(event);
-  const takeBackCards = sendEvent({Action: 'TakeBackCards'});
-  const endTrick = sendEvent({Action: 'EndTrick'});
-  const startNewGame = sendEvent({Action: 'StartNewGame'});
+  const takeBackCards = sendEvent({ Action: 'TakeBackCards' });
+  const endTrick = sendEvent({ Action: 'EndTrick' });
+  const startNewGame = sendEvent({ Action: 'StartNewGame' });
 
-  const {playPhase} = props;
+  const { playPhase } = props;
 
   // TODO: instead of telling who the player is by checking the name, pass in
   // the Player object
@@ -92,6 +92,8 @@ const Play = (props: Props) => {
         players={playPhase.propagated.players}
         landlord={playPhase.landlord}
         landlords_team={playPhase.landlords_team}
+        next={nextPlayer}
+        name={props.name}
         showTrickInPlayerOrder={props.showTrickInPlayerOrder}
       />
       <AutoPlayButton
@@ -122,8 +124,12 @@ const Play = (props: Props) => {
         <div>
           <p>Previous trick</p>
           <Trick
-            trick={playPhase.last_trick}
+            trick={playPhase.trick}
             players={playPhase.propagated.players}
+            landlord={playPhase.landlord}
+            landlords_team={playPhase.landlords_team}
+            next={nextPlayer}
+            name={props.name}
             showTrickInPlayerOrder={props.showTrickInPlayerOrder}
           />
         </div>

--- a/frontend/src/Trick.tsx
+++ b/frontend/src/Trick.tsx
@@ -16,7 +16,7 @@ type Props = {
 const Trick = (props: Props) => {
   const namesById = ArrayUtils.mapObject(props.players, (p: IPlayer) => [
     String(p.id),
-    (p.id === props.landlord) ? (p.name + ' (landlord)') : (p.name),
+    (p.id === props.landlord) ? (p.name + ' \uD83D\uDC37') : (p.name),
   ]);
   const blankCards =
     props.trick.played_cards.length > 0
@@ -56,16 +56,18 @@ const Trick = (props: Props) => {
             : '', {
           landlord:
             id === props.landlord || props.landlords_team?.includes(id),
-          next: id === props.next,
-          you: props.name === props.players[id].name,
+          piggy:
+            id === props.landlord,
         });
 
         return (
           <LabeledPlay
             key={id}
+            id={id}
             label={namesById[id] + suffix}
             className={className}
             cards={cards}
+            next={props.next}
             moreCards={playedByID[id]?.bad_throw_cards}
           />
         );

--- a/frontend/src/Trick.tsx
+++ b/frontend/src/Trick.tsx
@@ -9,12 +9,14 @@ type Props = {
   landlord?: number | null;
   landlords_team?: number[];
   trick: ITrick;
+  next?: number | null;
+  name: string;
   showTrickInPlayerOrder: boolean;
 };
 const Trick = (props: Props) => {
   const namesById = ArrayUtils.mapObject(props.players, (p: IPlayer) => [
     String(p.id),
-    p.name,
+    (p.id === props.landlord) ? (p.name + ' (landlord)') : (p.name),
   ]);
   const blankCards =
     props.trick.played_cards.length > 0
@@ -54,6 +56,8 @@ const Trick = (props: Props) => {
             : '', {
           landlord:
             id === props.landlord || props.landlords_team?.includes(id),
+          next: id === props.next,
+          you: props.name === props.players[id].name,
         });
 
         return (

--- a/frontend/static/style.css
+++ b/frontend/static/style.css
@@ -31,9 +31,10 @@ button { padding: 10px; cursor: pointer; margin: 10px; }
 .hand p { margin: 0; text-align: center; }
 .hand .unselected-cards { padding: 0 10px; }
 .hand .selected-cards { padding: 0 10px; }
-.next { color: #00f }
-.landlord { background: #ddd }
-.landlord .card { background: #ddd }
+.next { color: #b30ba6; }
+.you {border: 3px solid #0575ff;}
+.landlord { background: #4a9a7a }
+.landlord .card { background: #4a9a7a }
 .player { border: 1px #000 solid; padding: 10px; }
 .observer { border: 1px #222 dashed; color: #222; }
 .chat { min-width: 225px; width: 20%; border: 1px #eee solid; float: right; margin-top: 20px; }
@@ -45,9 +46,10 @@ button { padding: 10px; cursor: pointer; margin: 10px; }
 .labeled-play { display: inline-block; padding: 10px; border: 1px solid #000; }
 .labeled-play .label { text-align: center }
 .labeled-play .card { cursor: default; }
-.labeled-play.winning { background: #efefef; }
-.labeled-play.winning .card { background: #efefef; }
-.labeled-play.winning.landlord { background: #ddd; }
+.labeled-play.you {border: 3px solid #0575ff;}
+/* .labeled-play.winning { background: #efed9fa6; } */
+.labeled-play.winning .card { background: #efed9f; }
+.labeled-play.winning.landlord { background: #4a9a7a; }
 .labeled-play .more .card { font-size: 6em; }
 .labeled-play .play { display: inline-block; }
 .trump { margin: 10px 0; }

--- a/frontend/static/style.css
+++ b/frontend/static/style.css
@@ -31,10 +31,9 @@ button { padding: 10px; cursor: pointer; margin: 10px; }
 .hand p { margin: 0; text-align: center; }
 .hand .unselected-cards { padding: 0 10px; }
 .hand .selected-cards { padding: 0 10px; }
-.next { color: #b30ba6; }
-.you {border: 3px solid #0575ff;}
-.landlord { background: #4a9a7a }
-.landlord .card { background: #4a9a7a }
+.next { color: blue; font-weight: bold; }
+.landlord { background: #ddd; }
+.landlord .card { background: #ddd; }
 .player { border: 1px #000 solid; padding: 10px; }
 .observer { border: 1px #222 dashed; color: #222; }
 .chat { min-width: 225px; width: 20%; border: 1px #eee solid; float: right; margin-top: 20px; }
@@ -46,10 +45,10 @@ button { padding: 10px; cursor: pointer; margin: 10px; }
 .labeled-play { display: inline-block; padding: 10px; border: 1px solid #000; }
 .labeled-play .label { text-align: center }
 .labeled-play .card { cursor: default; }
-.labeled-play.you {border: 3px solid #0575ff;}
-/* .labeled-play.winning { background: #efed9fa6; } */
-.labeled-play.winning .card { background: #efed9f; }
-.labeled-play.winning.landlord { background: #4a9a7a; }
+.labeled-play.you {border: 3px solid #00f; }
+.labeled-play.winning { border: 2px solid #bb0313; }
+.labeled-play.winning.landlord { background: #ddd; }
+.labeled-play.piggy { padding: 7px; }
 .labeled-play .more .card { font-size: 6em; }
 .labeled-play .play { display: inline-block; }
 .trump { margin: 10px 0; }


### PR DESCRIPTION
…e info the player list carries

in addition to the bg color change, player list label and coloring for landlord, you, next are all moved down to the trick list.

I spent quite a bit of time trying to get an image file into the code base without success (to be used for showing an icon for the landlord player:)). Don't know enough about the warp crate used in main.rs to do it.

anyway, once the play starts, "you" will have a blue border, can't use 当庄 in the label for playing cards, they are too big. (I wanted to use a bg img to replace it anyway)

winning card will have a bright yellow bg, but only covering the card, not the entire card area, so that team bg color can still be prominent enough.

next player label color is changed to a purplish color so that it displays better than blue.

I played a bit with hiding the player list when play starts, but decided not to do it because observer list still need to be displayed.

Anyway, we probably should look into using some kind of css framework, like bootstrap to get the UI better. Thoughts?

![Screen Shot 2020-06-13 at 5 08 23 PM](https://user-images.githubusercontent.com/4054100/84581652-8965b600-ad98-11ea-97a8-bab424028905.png)
 
