### PR TITLE
only mark next if next is provided

### DIFF
--- a/frontend/src/Credits.tsx
+++ b/frontend/src/Credits.tsx
@@ -29,6 +29,10 @@ const ChangeLog = () => {
         style={{content: contentStyle}}
       >
         <h2>Change Log</h2>
+        <p>6/17/2020:</p>
+        <ul>
+          <li>Fix bug where points display was highlighted blue.</li>
+        </ul>
         <p>6/14/2020:</p>
         <ul>
           <li>Fix bug where previous-trick showed current trick.</li>

--- a/frontend/src/LabeledPlay.tsx
+++ b/frontend/src/LabeledPlay.tsx
@@ -12,7 +12,7 @@ type Props = {
 };
 const LabeledPlay = (props: Props) => {
   const className = classNames('label', {
-    next: props.id === props.next,
+    next: props.next !== null && props.id === props.next,
   });
 
   return (


### PR DESCRIPTION
`null === null`, so this was making every LabeledPlay have the `next` class