### PR TITLE
Fix race in healthcheck callback

### DIFF
--- a/frontend/src/WebsocketProvider.tsx
+++ b/frontend/src/WebsocketProvider.tsx
@@ -93,7 +93,7 @@ const WebsocketProvider: React.FunctionComponent<{}> = (props) => {
 
     const localTimerRef = setTimeoutRef.current(() => {
       if (timerRef.current === localTimerRef) {
-        updateStateRef.current({connected: false});
+        updateStateRef.current({ connected: false });
       }
     }, 5000);
 

--- a/frontend/src/WebsocketProvider.tsx
+++ b/frontend/src/WebsocketProvider.tsx
@@ -90,11 +90,14 @@ const WebsocketProvider: React.FunctionComponent<{}> = (props) => {
     }
     // We expect a response back from the server within 5 seconds. Otherwise,
     // we should assume we have lost our websocket connection.
-    setTimerRef.current(
-      setTimeoutRef.current(() => {
-        updateStateRef.current({ connected: false });
-      }, 5000)
-    );
+
+    const localTimerRef = setTimeoutRef.current(() => {
+      if (timerRef.current === localTimerRef) {
+        updateStateRef.current({connected: false});
+      }
+    }, 5000);
+
+    setTimerRef.current(localTimerRef);
     websocket?.send(JSON.stringify(value));
   };
   // TODO(read this from consumers instead of globals)


### PR DESCRIPTION
Fix race where the old callback and the new callback might interleave,
causing the healthcheck timer to unexpectedly fire. Preventing the timer
from firing is complex, especially since the setTimeout call is actually
running in a web worker, but we know that the healthcheck is only valid
if it's still the most recent timer, so we can resolve the user-facing
issue.