### PR TITLE
Show throw breakdowns in the UI

### DIFF
--- a/frontend/src/Card.tsx
+++ b/frontend/src/Card.tsx
@@ -1,15 +1,16 @@
 import * as React from "react";
-import classNames from "classnames";
-import { cardLookup } from "./util/cardHelpers";
-import InlineCard from "./InlineCard";
 
-type Props = {
+import classNames from "classnames";
+import InlineCard from "./InlineCard";
+import { cardLookup } from "./util/cardHelpers";
+
+interface IProps {
   card: string;
   className?: string;
   onClick?: (event: React.MouseEvent) => void;
-};
+}
 
-const Card = (props: Props) => {
+const Card = (props: IProps) => {
   const cardInfo = cardLookup[props.card];
   if (!cardInfo) {
     return (

--- a/frontend/src/InlineCard.tsx
+++ b/frontend/src/InlineCard.tsx
@@ -1,6 +1,10 @@
 import * as React from "react";
-import { unicodeToCard, cardToUnicodeSuit, SuitCard } from "./util/cardHelpers";
 import styled from "styled-components";
+import {
+  cardToUnicodeSuit,
+  ISuitCard,
+  unicodeToCard,
+} from "./util/cardHelpers";
 
 const InlineCardBase = styled.span`
   padding-left: 0.1em;
@@ -18,7 +22,7 @@ const LittleJoker = Suit("🃟");
 const BigJoker = Suit("🃏");
 const Unknown = Suit("🂠");
 
-const suitComponent = (suitCard: SuitCard) => {
+const suitComponent = (suitCard: ISuitCard) => {
   switch (suitCard.suit) {
     case "diamonds":
       return Diamonds;

--- a/frontend/src/LabeledPlay.tsx
+++ b/frontend/src/LabeledPlay.tsx
@@ -1,16 +1,18 @@
 import * as React from "react";
+
 import classNames from "classnames";
 import Card from "./Card";
 
-type Props = {
+interface IProps {
   id?: number | null;
   className?: string;
-  cards: string[];
+  cards?: string[];
+  groupedCards?: string[][];
   moreCards?: string[];
   label: string;
   next?: number | null;
-};
-const LabeledPlay = (props: Props) => {
+}
+const LabeledPlay = (props: IProps) => {
   const className = classNames("label", {
     next:
       props.next !== undefined &&
@@ -18,13 +20,20 @@ const LabeledPlay = (props: Props) => {
       props.id === props.next,
   });
 
-  return (
-    <div className={classNames("labeled-play", props.className)}>
-      <div className="play">
-        {props.cards.map((card, idx) => (
-          <Card card={card} key={idx} />
+  const cards = props.cards.map((card, idx) => <Card card={card} key={idx} />);
+
+  const groupedCards =
+    props.groupedCards?.map((c, gidx) => (
+      <div className="card-group" key={gidx}>
+        {c.map((card, idx) => (
+          <Card card={card} key={gidx + "-" + idx} />
         ))}
       </div>
+    )) || cards;
+
+  return (
+    <div className={classNames("labeled-play", props.className)}>
+      <div className="play">{groupedCards}</div>
       {props.moreCards && props.moreCards.length > 0 ? (
         <div className="play more">
           {props.moreCards.map((card, idx) => (

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -121,6 +121,7 @@ export interface IPlayer {
 export interface ITrick {
   player_queue: number[];
   played_cards: IPlayedCards[];
+  played_card_mappings: ICardMapping[];
   current_winner: number | null;
   trump: ITrump;
 }
@@ -130,6 +131,24 @@ export interface IPlayedCards {
   cards: string[];
   bad_throw_cards: string[];
   better_player: number | null;
+}
+
+export type ICardMapping = ITrickUnit[] | null;
+
+export interface ITrickUnit {
+  Repeated?: {
+    card: IOrderedCard;
+    count: number;
+  };
+  Tractor?: {
+    members: IOrderedCard[];
+    count: number;
+  };
+}
+
+export interface IOrderedCard {
+  card: string;
+  // elided fields
 }
 
 export type ITrump =

--- a/frontend/src/util/array.ts
+++ b/frontend/src/util/array.ts
@@ -42,8 +42,8 @@ const range = <T>(count: number, fn: (idx: number) => T): T[] =>
     .map((_, idx) => fn(idx));
 
 export default {
-  sum,
+  mapObject,
   minus,
   range,
-  mapObject,
+  sum,
 };

--- a/frontend/src/util/cardHelpers.ts
+++ b/frontend/src/util/cardHelpers.ts
@@ -1,6 +1,6 @@
 import preloadedCards from "../preloadedCards";
-import ArrayUtils from "../util/array";
 import { ICardInfo } from "../types";
+import ArrayUtils from "../util/array";
 
 export const cardLookup = ArrayUtils.mapObject(
   preloadedCards,
@@ -9,8 +9,8 @@ export const cardLookup = ArrayUtils.mapObject(
 
 // prettier-ignore
 type Rank = (
-  | 'A' | '2' | '3' | '4' | '5' | '6' | '7'
-  | '8' | '9' | '10' | 'J' | 'Q' | 'K'
+  | "A" | "2" | "3" | "4" | "5" | "6" | "7"
+  | "8" | "9" | "10" | "J" | "Q" | "K"
 );
 type Suit = "diamonds" | "clubs" | "hearts" | "spades";
 
@@ -27,14 +27,14 @@ const suitToFilledUnicode: { [key in Suit]: string } = {
   spades: "♠",
 };
 
-export type SuitCard = {
+export interface ISuitCard {
   type: "suit_card";
   rank: Rank;
   suit: Suit;
-};
+}
 
 type Card =
-  | SuitCard
+  | ISuitCard
   | { type: "big_joker" }
   | { type: "little_joker" }
   | { type: "unknown" };
@@ -69,15 +69,15 @@ export const unicodeToCard = (unicode: string): Card => {
     return { type: "big_joker" };
   } else {
     return {
-      type: "suit_card",
-      suit: cardInfoToSuit(cardInfo),
       rank: cardInfo.number as Rank,
+      suit: cardInfoToSuit(cardInfo),
+      type: "suit_card",
     };
   }
 };
 
 export const cardToUnicodeSuit = (
-  card: SuitCard,
+  card: ISuitCard,
   fill: boolean = true
 ): string => {
   const table = fill ? suitToFilledUnicode : suitToUnicode;

--- a/frontend/static/style.css
+++ b/frontend/static/style.css
@@ -44,6 +44,7 @@ button { padding: 10px; cursor: pointer; margin: 10px; }
 .game-message { color: #00f; }
 .labeled-play { display: inline-block; padding: 10px; border: 1px solid #000; }
 .labeled-play .label { text-align: center; line-height: 1em; }
+.labeled-play .card-group { display: inline-block; }
 .labeled-play .card { cursor: default; }
 .labeled-play.winning { box-shadow: inset 0px 0px 0px 2px #bb0313; }
 .labeled-play .more .card { font-size: 6em; }

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -5,7 +5,7 @@
     "target": "es5",
     "jsx": "react",
     "allowJs": true,
-    "lib": ["dom", "es6", "es2017", "esnext.asynciterable"],
+    "lib": ["dom", "es6", "es2017", "esnext.asynciterable", "esnext.array"],
     "noUnusedLocals": true
   },
   "include": ["src"],


### PR DESCRIPTION
When a throw is made, show the individual components of the throw
separately -- except that the throw components which are single cards,
which should be grouped together.

Fixes #29