### PR TITLE
Add a "meta-level" concept and wrap ranks after A

### DIFF
--- a/frontend/src/Credits.tsx
+++ b/frontend/src/Credits.tsx
@@ -29,6 +29,11 @@ const ChangeLog = () => {
         style={{ content: contentStyle }}
       >
         <h2>Change Log</h2>
+        <p>6/20/2020:</p>
+        <ul>
+          <li>Add the ability to wrap-around after defending on "A".</li>
+          <li>Show throw breakdowns in the UI to make throws more obvious.</li>
+        </ul>
         <p>6/17/2020:</p>
         <ul>
           <li>Fix bug where points display was highlighted blue.</li>

--- a/frontend/src/Players.tsx
+++ b/frontend/src/Players.tsx
@@ -1,10 +1,11 @@
 import * as React from "react";
-import { IPlayer } from "./types";
+
 import classNames from "classnames";
 import { MovePlayerLeft, MovePlayerRight } from "./MovePlayerButton";
+import { IPlayer } from "./types";
 import { WebsocketContext } from "./WebsocketProvider";
 
-type Props = {
+interface IProps {
   players: IPlayer[];
   observers: IPlayer[];
   landlord?: number | null;
@@ -12,9 +13,9 @@ type Props = {
   movable?: boolean;
   next?: number | null;
   name: string;
-};
+}
 
-const Players = (props: Props) => {
+const Players = (props: IProps) => {
   const {
     players,
     observers,
@@ -26,25 +27,33 @@ const Players = (props: Props) => {
   } = props;
   const { send } = React.useContext(WebsocketContext);
 
+  const makeDescriptor = (p: IPlayer) => {
+    if (p.metalevel <= 1) {
+      return [`${p.name} (rank ${p.level})`];
+    } else {
+      return [`${p.name} (rank ${p.level}`, <sup>{p.metalevel}</sup>, ")"];
+    }
+  };
+
   return (
     <table className="players">
       <tbody>
         <tr>
           {players.map((player) => {
             const className = classNames("player", {
-              next: player.id === next,
               landlord:
                 player.id === landlord || landlords_team?.includes(player.id),
               movable,
+              next: player.id === next,
             });
 
-            let descriptor = `${player.name} (rank ${player.level})`;
+            const descriptor = makeDescriptor(player);
 
             if (player.id === landlord) {
-              descriptor = descriptor + " (当庄)";
+              descriptor.push(" (当庄)");
             }
             if (player.name === name) {
-              descriptor = descriptor + " (You!)";
+              descriptor.push(" (You!)");
             }
 
             return (
@@ -53,15 +62,15 @@ const Players = (props: Props) => {
                 {movable && (
                   <span
                     style={{
+                      display: "block",
                       textAlign: "center",
                       width: "100%",
-                      display: "block",
                     }}
                   >
                     <MovePlayerLeft players={players} player={player} />
                     <span
                       style={{ cursor: "pointer" }}
-                      onClick={(evt) => {
+                      onClick={(_) => {
                         send({ Action: { MakeObserver: player.id } });
                       }}
                     >
@@ -75,10 +84,10 @@ const Players = (props: Props) => {
           })}
           {observers.map((player) => {
             const className = classNames("player observer", { movable });
-            let descriptor = `${player.name} (rank ${player.level})`;
+            const descriptor = makeDescriptor(player);
 
             if (player.name === name) {
-              descriptor = descriptor + " (You!)";
+              descriptor.push(" (You!)");
             }
 
             return (
@@ -89,14 +98,14 @@ const Players = (props: Props) => {
                 {movable && (
                   <span
                     style={{
+                      display: "block",
                       textAlign: "center",
                       width: "100%",
-                      display: "block",
                     }}
                   >
                     <span
                       style={{ cursor: "pointer" }}
-                      onClick={(evt) => {
+                      onClick={(_) => {
                         send({ Action: { MakePlayer: player.id } });
                       }}
                     >

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -2,6 +2,7 @@ export interface IPlayer {
   id: number;
   name: string;
   level: string;
+  metalevel: number;
 }
 
 export interface IGameState {


### PR DESCRIPTION
Some people like to keep playing after the A rank. In theory, it would
probably be best to have an "NT" rank, but as an intermediary step,
let's allow players to keep track of an ephemeral "meta-level". Note:
there is no mechanism currently to _set_ the meta-level, though it
wouldn't be a big deal to add one.

Part of the prerequisites for #141