### PR TITLE
Add a game separator message to visually separate a new game from pre…

### DIFF
--- a/core/src/interactive.rs
+++ b/core/src/interactive.rs
@@ -75,10 +75,7 @@ impl InteractiveGame {
             (Message::StartGame, GameState::Initialize(ref mut state)) => {
                 info!(logger, "Starting game");
                 self.state = GameState::Draw(state.start()?);
-                vec![
-                    MessageVariant::GameSeparator,
-                    MessageVariant::StartingGame,
-                ]
+                vec![MessageVariant::GameSeparator, MessageVariant::StartingGame]
             }
             (Message::ReorderPlayers(ref players), GameState::Initialize(ref mut state)) => {
                 info!(logger, "Reordering players");

--- a/core/src/interactive.rs
+++ b/core/src/interactive.rs
@@ -75,7 +75,10 @@ impl InteractiveGame {
             (Message::StartGame, GameState::Initialize(ref mut state)) => {
                 info!(logger, "Starting game");
                 self.state = GameState::Draw(state.start()?);
-                vec![MessageVariant::StartingGame]
+                vec![
+                    MessageVariant::GameSeparator,
+                    MessageVariant::StartingGame,
+                ]
             }
             (Message::ReorderPlayers(ref players), GameState::Initialize(ref mut state)) => {
                 info!(logger, "Reordering players");
@@ -335,6 +338,7 @@ impl BroadcastMessage {
         use MessageVariant::*;
         Ok(match self.variant {
             ResettingGame => format!("{} reset the game", n?),
+            GameSeparator => "🚜 🚜 🚜 🚜 🚜 🚜 🚜 🚜 🚜 🚜".to_string(),
             StartingGame => format!("{} started the game", n?),
             TrickWon { winner, points } =>if points > 0 {
                     format!("{} wins the trick and gets {} points", player_name(winner)?, points)

--- a/core/src/message.rs
+++ b/core/src/message.rs
@@ -15,6 +15,7 @@ use crate::types::{Card, Number, PlayerID};
 pub enum MessageVariant {
     ResettingGame,
     StartingGame,
+    GameSeparator,
     TrickWon {
         winner: PlayerID,
         points: usize,


### PR DESCRIPTION
…vious one in the chat box.

people tend to click on finish game and start right away, making it difficult to read about last game's summary.

We may need to improve this so that just finished game can be better summarized and presented. But for now, this will make it easier so that no one needs to type in something  like "=========" quickly before a new game starts