### PR TITLE
restrict game start to the landlord unless no landlord is determined

### DIFF
--- a/core/src/game_state.rs
+++ b/core/src/game_state.rs
@@ -2090,7 +2090,7 @@ mod tests {
         let p2 = init.add_player("p2".into()).unwrap().0;
         let p3 = init.add_player("p3".into()).unwrap().0;
         let p4 = init.add_player("p4".into()).unwrap().0;
-        let mut draw = init.start().unwrap();
+        let mut draw = init.start(PlayerID(0)).unwrap();
         // Hackily ensure that everyone can bid.
         draw.deck = vec![
             cards::S_2,
@@ -2129,7 +2129,7 @@ mod tests {
         let p4 = init.add_player("p4".into()).unwrap().0;
         init.set_kitty_theft_policy(KittyTheftPolicy::AllowKittyTheft)
             .unwrap();
-        let mut draw = init.start().unwrap();
+        let mut draw = init.start(PlayerID(0)).unwrap();
         // Hackily ensure that everyone can bid.
         draw.deck = vec![
             cards::S_2,
@@ -2178,7 +2178,7 @@ mod tests {
         let p2 = init.add_player("p2".into()).unwrap().0;
         let p3 = init.add_player("p3".into()).unwrap().0;
         let p4 = init.add_player("p4".into()).unwrap().0;
-        let mut draw = init.start().unwrap();
+        let mut draw = init.start(PlayerID(0)).unwrap();
 
         let p1_hand = vec![S_9, S_9, S_10, S_10, S_K, S_3, S_4, S_5, S_7, S_7, H_2];
         let p2_hand = vec![S_3, S_3, S_5, S_5, S_7, S_8, S_J, S_Q, C_3, C_4, C_5];
@@ -2233,7 +2233,7 @@ mod tests {
         init.set_landlord(Some(p2)).unwrap();
         init.set_rank(p2, Number::Seven).unwrap();
 
-        let mut draw = init.start().unwrap();
+        let mut draw = init.start(PlayerID(1)).unwrap();
 
         let p1_hand = vec![
             Card::SmallJoker,
@@ -2749,7 +2749,7 @@ mod tests {
         init.set_landlord(Some(p1)).unwrap();
         init.set_rank(p1, Number::Seven).unwrap();
 
-        let mut draw = init.start().unwrap();
+        let mut draw = init.start(PlayerID(0)).unwrap();
         let mut deck = vec![];
 
         // We need at least two cards per person, since the landlord needs to

--- a/core/src/game_state.rs
+++ b/core/src/game_state.rs
@@ -1778,9 +1778,21 @@ impl InitializePhase {
         }
     }
 
-    pub fn start(&self) -> Result<DrawPhase, Error> {
+    pub fn start(&self, id: PlayerID) -> Result<DrawPhase, Error> {
         if self.propagated.players.len() < 4 {
             bail!("not enough players")
+        }
+
+        match self.propagated.landlord {
+            None => (),
+            Some(player_id) => {
+                if player_id != id {
+                    bail!(format!(
+                        "player {} is not allowed to start game!",
+                        self.propagated.players[id.0].name
+                    ))
+                }
+            }
         }
 
         let game_mode = match self.propagated.game_mode {

--- a/core/src/game_state.rs
+++ b/core/src/game_state.rs
@@ -1783,16 +1783,8 @@ impl InitializePhase {
             bail!("not enough players")
         }
 
-        match self.propagated.landlord {
-            None => (),
-            Some(player_id) => {
-                if player_id != id {
-                    bail!(format!(
-                        "player {} is not allowed to start game!",
-                        self.propagated.players[id.0].name
-                    ))
-                }
-            }
+        if self.propagated.landlord.map(|l| l != id).unwrap_or(false) {
+            bail!("Only the landlord can start the game")
         }
 
         let game_mode = match self.propagated.game_mode {

--- a/core/src/interactive.rs
+++ b/core/src/interactive.rs
@@ -80,7 +80,7 @@ impl InteractiveGame {
             }
             (Message::StartGame, GameState::Initialize(ref mut state)) => {
                 info!(logger, "Starting game");
-                self.state = GameState::Draw(state.start()?);
+                self.state = GameState::Draw(state.start(id)?);
                 vec![MessageVariant::StartingGame]
             }
             (Message::ReorderPlayers(ref players), GameState::Initialize(ref mut state)) => {

--- a/core/src/interactive.rs
+++ b/core/src/interactive.rs
@@ -5,8 +5,9 @@ use slog::{debug, info, o, Logger};
 use crate::bidding::{BidPolicy, BidTakebackPolicy};
 use crate::game_state::{
     AdvancementPolicy, BonusLevelPolicy, FirstLandlordSelectionPolicy, FriendSelection,
-    FriendSelectionPolicy, GameModeSettings, GameShadowingPolicy, GameState, InitializePhase,
-    KittyBidPolicy, KittyPenalty, KittyTheftPolicy, PlayTakebackPolicy, ThrowPenalty,
+    FriendSelectionPolicy, GameModeSettings, GameShadowingPolicy, GameStartPolicy, GameState,
+    InitializePhase, KittyBidPolicy, KittyPenalty, KittyTheftPolicy, PlayTakebackPolicy,
+    ThrowPenalty,
 };
 use crate::message::MessageVariant;
 use crate::trick::{ThrowEvaluationPolicy, TrickDrawPolicy};
@@ -205,6 +206,10 @@ impl InteractiveGame {
                 info!(logger, "Setting user multiple game session policy"; "policy" => format!("{:?}", policy));
                 state.set_user_multiple_game_session_policy(policy)?
             }
+            (Message::SetGameStartPolicy(policy), GameState::Initialize(ref mut state)) => {
+                info!(logger, "Setting game start policy"; "policy" => format!("{:?}", policy));
+                state.set_game_start_policy(policy)?
+            }
             (Message::DrawCard, GameState::Draw(ref mut state)) => {
                 debug!(logger, "Drawing card");
                 state.draw_card(id)?;
@@ -350,6 +355,7 @@ pub enum Message {
     SetBidTakebackPolicy(BidTakebackPolicy),
     SetKittyTheftPolicy(KittyTheftPolicy),
     SetGameShadowingPolicy(GameShadowingPolicy),
+    SetGameStartPolicy(GameStartPolicy),
     StartGame,
     DrawCard,
     RevealCard,
@@ -452,6 +458,8 @@ impl BroadcastMessage {
             KittyTheftPolicySet { policy: KittyTheftPolicy::NoKittyTheft } => format!("{} disabled stealing the bottom cards after the leader", n?),
             GameShadowingPolicySet { policy: GameShadowingPolicy::AllowMultipleSessions } => format!("{} allowed players to be shadowed by joining with the same name", n?),
             GameShadowingPolicySet { policy: GameShadowingPolicy::SingleSessionOnly } => format!("{} prohibited players from being shadowed", n?),
+            GameStartPolicySet { policy: GameStartPolicy::AllowAnyPlayer } => format!("{} allowed any player to start a game", n?),
+            GameStartPolicySet { policy: GameStartPolicy::AllowLandlordOnly } => format!("{} allowed only landlord to start a game", n?),
             RevealedCardFromKitty => format!("{} revealed a card from the bottom of the deck", n?),
             PickedUpCards => format!("{} picked up the bottom cards", n?),
             PutDownCards => format!("{} put down the bottom cards", n?),

--- a/core/src/message.rs
+++ b/core/src/message.rs
@@ -5,8 +5,8 @@ use serde::{Deserialize, Serialize};
 use crate::bidding::{BidPolicy, BidTakebackPolicy};
 use crate::game_state::{
     AdvancementPolicy, BonusLevelPolicy, FirstLandlordSelectionPolicy, FriendSelectionPolicy,
-    GameModeSettings, GameShadowingPolicy, KittyBidPolicy, KittyPenalty, KittyTheftPolicy,
-    PlayTakebackPolicy, PlayerGameFinishedResult, ThrowPenalty,
+    GameModeSettings, GameShadowingPolicy, GameStartPolicy, KittyBidPolicy, KittyPenalty,
+    KittyTheftPolicy, PlayTakebackPolicy, PlayerGameFinishedResult, ThrowPenalty,
 };
 use crate::trick::{ThrowEvaluationPolicy, TrickDrawPolicy};
 use crate::types::{Card, Number, PlayerID};
@@ -129,6 +129,9 @@ pub enum MessageVariant {
     },
     GameShadowingPolicySet {
         policy: GameShadowingPolicy,
+    },
+    GameStartPolicySet {
+        policy: GameStartPolicy,
     },
     PickedUpCards,
     PutDownCards,

--- a/frontend/src/Credits.tsx
+++ b/frontend/src/Credits.tsx
@@ -29,6 +29,14 @@ const ChangeLog = (): JSX.Element => {
         style={{ content: contentStyle }}
       >
         <h2>Change Log</h2>
+        <p>7/10/2020:</p>
+        <ul>
+          <li>Only landlord has the privilege to start a new game.</li>
+        </ul>
+        <p>7/09/2020:</p>
+        <ul>
+          <li>game option for game shadowing</li>
+        </ul>
         <p>7/02/2020:</p>
         <ul>
           <li>(#171) Add game option disable taking back bids</li>

--- a/frontend/src/Credits.tsx
+++ b/frontend/src/Credits.tsx
@@ -29,9 +29,9 @@ const ChangeLog = (): JSX.Element => {
         style={{ content: contentStyle }}
       >
         <h2>Change Log</h2>
-        <p>7/10/2020:</p>
+        <p>7/15/2020:</p>
         <ul>
-          <li>Only landlord has the privilege to start a new game.</li>
+          <li>add game option for starting a game</li>
         </ul>
         <p>7/09/2020:</p>
         <ul>

--- a/frontend/src/Initialize.tsx
+++ b/frontend/src/Initialize.tsx
@@ -216,6 +216,19 @@ const Initialize = (props: IProps): JSX.Element => {
     }
   };
 
+  const setGameStartPolicy = (
+    evt: React.ChangeEvent<HTMLSelectElement>
+  ): void => {
+    evt.preventDefault();
+    if (evt.target.value !== "") {
+      send({
+        Action: {
+          SetGameStartPolicy: evt.target.value,
+        },
+      });
+    }
+  };
+
   const setAdvancementPolicy = (
     evt: React.ChangeEvent<HTMLSelectElement>
   ): void => {
@@ -505,6 +518,13 @@ const Initialize = (props: IProps): JSX.Element => {
               },
             });
             break;
+          case "game_start_policy":
+            send({
+              Action: {
+                SetGameStartPolicy: value,
+              },
+            });
+            break;
         }
       }
     }
@@ -562,6 +582,7 @@ const Initialize = (props: IProps): JSX.Element => {
       {props.state.propagated.players.length >= 4 ? (
         <button
           disabled={
+            props.state.propagated.game_start_policy === "AllowLandlordOnly" &&
             props.state.propagated.landlord != null &&
             props.state.propagated.players[props.state.propagated.landlord]
               .name !== props.name
@@ -919,6 +940,22 @@ const Initialize = (props: IProps): JSX.Element => {
               </option>
               <option value="SingleSessionOnly">
                 Do not allow players to be shadowed
+              </option>
+            </select>
+          </label>
+        </div>
+        <div>
+          <label>
+            Game start policy:{" "}
+            <select
+              value={props.state.propagated.game_start_policy}
+              onChange={setGameStartPolicy}
+            >
+              <option value="AllowAnyPlayer">
+                Allow any player to start a game
+              </option>
+              <option value="AllowLandlordOnly">
+                Allow only landlord to start a game
               </option>
             </select>
           </label>

--- a/frontend/src/Initialize.tsx
+++ b/frontend/src/Initialize.tsx
@@ -560,7 +560,16 @@ const Initialize = (props: IProps): JSX.Element => {
         </a>
       </p>
       {props.state.propagated.players.length >= 4 ? (
-        <button onClick={startGame}>Start game</button>
+        <button
+          disabled={
+            props.state.propagated.landlord != null &&
+            props.state.propagated.players[props.state.propagated.landlord]
+              .name !== props.name
+          }
+          onClick={startGame}
+        >
+          Start game
+        </button>
       ) : (
         <h2>Waiting for players...</h2>
       )}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -152,6 +152,7 @@ export interface IPropagatedState {
   bid_takeback_policy: "AllowBidTakeback" | "NoBidTakeback";
   kitty_theft_policy: "AllowKittyTheft" | "NoKittyTheft";
   game_shadowing_policy: "AllowMultipleSessions" | "SingleSessionOnly";
+  game_start_policy: "AllowAnyPlayer" | "AllowLandlordOnly";
 }
 
 export interface IHands {


### PR DESCRIPTION
the request is landlord should have the exclusive privilege to start the game during play. (currently, the end game notification indicates the landlord will start the game, but anyone can). Some newly minted landlord feels HER hard earned victory was not sufficiently rewarded without the exclusive privilege to start a new game:) 