### PR TITLE
Tighten card boundaries using Canvas tricks

### DIFF
--- a/frontend/shengji-wasm/src/lib.rs
+++ b/frontend/shengji-wasm/src/lib.rs
@@ -56,6 +56,7 @@ struct FindValidBidsResult {
 
 #[wasm_bindgen]
 pub fn find_valid_bids(req: JsValue) -> Result<JsValue, JsValue> {
+    #[cfg(debug_assertions)]
     console_error_panic_hook::set_once();
 
     let req: FindValidBidsRequest = req

--- a/frontend/src/Card.tsx
+++ b/frontend/src/Card.tsx
@@ -22,7 +22,7 @@ const Card = (props: IProps): JSX.Element => {
       <span className={classNames("card", "unknown", props.className)}>
         <CardCanvas
           card={props.card}
-          height={props.smaller ? 115 : 135}
+          height={props.smaller ? 95 : 120}
           suit={classNames("unknown", settings.fourColor ? "four-color" : null)}
         />
       </span>
@@ -57,7 +57,7 @@ const Card = (props: IProps): JSX.Element => {
         </div>
         <CardCanvas
           card={cardInfo.display_value}
-          height={props.smaller ? 115 : 135}
+          height={props.smaller ? 95 : 120}
           suit={classNames(
             cardInfo.typ,
             settings.fourColor ? "four-color" : null
@@ -139,7 +139,9 @@ const CardCanvas = (props: ICardCanvasProps): JSX.Element => {
       2
   );
   const effectiveWidth = Math.round(
-    textMetrics.actualBoundingBoxRight + textMetrics.actualBoundingBoxLeft + 2
+    textMetrics.actualBoundingBoxRight +
+      Math.min(textMetrics.actualBoundingBoxLeft, 0) +
+      2
   );
   return (
     <svg
@@ -160,7 +162,7 @@ const CardCanvas = (props: ICardCanvasProps): JSX.Element => {
         fill={style}
         fontSize={`${props.height}px`}
         textLength={`${textMetrics.width}px`}
-        x={textMetrics.actualBoundingBoxLeft + 1}
+        x={Math.min(textMetrics.actualBoundingBoxLeft, 0) + 1}
         y={effectiveHeight - textMetrics.actualBoundingBoxDescent - 1}
       >
         {props.card}

--- a/frontend/src/Card.tsx
+++ b/frontend/src/Card.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 
 import classNames from "classnames";
+import memoize from "./memoize";
 import InlineCard from "./InlineCard";
 import { cardLookup } from "./util/cardHelpers";
 import { SettingsContext } from "./AppStateProvider";
@@ -19,7 +20,11 @@ const Card = (props: IProps): JSX.Element => {
   if (!(props.card in cardLookup)) {
     const nonSVG = (
       <span className={classNames("card", "unknown", props.className)}>
-        {props.card}
+        <CardCanvas
+          card={props.card}
+          height={props.smaller ? 95 : 120}
+          suit={classNames("unknown", settings.fourColor ? "four-color" : null)}
+        />
       </span>
     );
 
@@ -50,7 +55,14 @@ const Card = (props: IProps): JSX.Element => {
         <div className="card-label">
           <InlineCard card={props.card} />
         </div>
-        {cardInfo.display_value}
+        <CardCanvas
+          card={cardInfo.display_value}
+          height={props.smaller ? 95 : 120}
+          suit={classNames(
+            cardInfo.typ,
+            settings.fourColor ? "four-color" : null
+          )}
+        />
       </span>
     );
 
@@ -76,6 +88,81 @@ const Card = (props: IProps): JSX.Element => {
       return nonSVG;
     }
   }
+};
+
+const computeCanvasBounds = (font: string): [number, number, number] => {
+  const c = document.createElement("canvas");
+  c.style.display = "none";
+  document.body.appendChild(c);
+  const ctx = c.getContext("2d");
+  ctx.font = font;
+  const text = "🂠";
+  const textMetrics = ctx.measureText(text);
+  const width =
+    textMetrics.actualBoundingBoxLeft + textMetrics.actualBoundingBoxRight;
+  const height =
+    textMetrics.actualBoundingBoxAscent + textMetrics.actualBoundingBoxDescent;
+  document.body.removeChild(c);
+  return [width, height, textMetrics.actualBoundingBoxDescent];
+};
+
+const computeSuitColor = (suit: string): string => {
+  const c = document.createElement("span");
+  c.className = suit;
+  c.style.display = "none";
+  document.body.appendChild(c);
+  const color = getComputedStyle(c).color;
+  document.body.removeChild(c);
+  return color;
+};
+
+const cardBoundsCache: { [font: string]: () => [number, number, number] } = {};
+const suitColorCache: { [suit: string]: () => string } = {};
+
+interface ICardCanvasProps {
+  card: string;
+  height: number;
+  suit: string;
+}
+
+const CardCanvas = (props: ICardCanvasProps): JSX.Element => {
+  const canvasRef = React.useRef<HTMLCanvasElement>(null);
+  const dpr =
+    (window.devicePixelRatio !== undefined ? window.devicePixelRatio : 1) * 1.5;
+  const font = `${props.height * dpr}px solid`;
+  if (!(font in cardBoundsCache)) {
+    cardBoundsCache[font] = memoize(() => computeCanvasBounds(font));
+  }
+  if (!(props.suit in suitColorCache)) {
+    suitColorCache[props.suit] = memoize(() => computeSuitColor(props.suit));
+  }
+  const [width, height, offset] = cardBoundsCache[font]();
+  const style = suitColorCache[props.suit]();
+
+  React.useEffect(() => {
+    const canvas = canvasRef.current;
+    const ctx = canvas.getContext("2d");
+    ctx.font = font;
+    ctx.textAlign = "center";
+    ctx.textBaseline = "bottom";
+    ctx.clearRect(0, 0, width + 2, height + 2);
+    ctx.fillStyle = "#fff";
+    ctx.fillRect(2, 2, width, height);
+    ctx.fillStyle = style;
+    ctx.fillText(props.card, width / 2 + 1, height + offset - 3 * dpr);
+  });
+
+  return (
+    <canvas
+      ref={canvasRef}
+      width={width + 2}
+      height={height + 2}
+      style={{
+        width: width / dpr + 2,
+        height: height / dpr + 2,
+      }}
+    />
+  );
 };
 
 export default Card;

--- a/frontend/static/rules.html
+++ b/frontend/static/rules.html
@@ -4,6 +4,9 @@
         <title>升级 / 找朋友 Rules</title>
         <meta charset="UTF-8">
         <link rel="stylesheet" type="text/css" href="style.css">
+        <style>
+          .card { background: #fff; height: inherit; }
+        </style>
     </head>
     <body id="body">
       <h1>Rules for 升级 and 找朋友</h1>
@@ -1097,6 +1100,41 @@
         rank and successfully defends it first. In this implementation, this
         is A.
       </p>
+      <script type="text/javascript">
+        const c = document.createElement("canvas");
+        c.width = 300;
+        c.height = 300;
+        c.style.border = '2px #000 solid';
+        // c.style.display = "none";
+        document.body.appendChild(c);
+        const ctx = c.getContext("2d");
+        ctx.font = "100px solid";
+        const text = "🂠";
+        const textMetrics = ctx.measureText(text);
+        const width =
+          textMetrics.actualBoundingBoxLeft + textMetrics.actualBoundingBoxRight;
+        const height =
+          textMetrics.actualBoundingBoxAscent + textMetrics.actualBoundingBoxDescent;
+        
+        // ctx.textAlign = "center";
+        // ctx.textBaseline = "middle";
+        const x = 150;
+        const y = 150;
+        ctx.fillText(text, x-2, y);
+        ctx.moveTo(0, y - textMetrics.actualBoundingBoxAscent);
+        ctx.lineTo(300, y - textMetrics.actualBoundingBoxAscent);
+        ctx.stroke();
+        ctx.moveTo(0, y + textMetrics.actualBoundingBoxDescent);
+        ctx.lineTo(300, y + textMetrics.actualBoundingBoxDescent);
+        ctx.stroke();
+        ctx.moveTo(x + textMetrics.actualBoundingBoxRight, 0);
+        ctx.lineTo(x + textMetrics.actualBoundingBoxRight, 300);
+        ctx.stroke();
+        ctx.moveTo(x - textMetrics.actualBoundingBoxLeft, 0);
+        ctx.lineTo(x - textMetrics.actualBoundingBoxLeft, 300);
+        ctx.stroke();
+        //document.body.removeChild(c);
+      </script>
 
       <script type="text/javascript">
         const body = document.getElementById("body");

--- a/frontend/static/style.css
+++ b/frontend/static/style.css
@@ -6,15 +6,18 @@ button.normal { padding: 2px; cursor: pointer; margin: 2px; line-height: 1em; }
 .player { border: 1px #000 solid; padding: 10px; line-height: 1em; }
 .errors { position: fixed; z-index: 100; background: #f00; color: #fff; padding: 0 10px; }
 .trick { padding: 10px; }
-.card { font-size: 8em; display: inline-block; cursor: pointer; margin-right: -0.4em; background: #fff; user-select: none; font-family: "Segoe UI Symbol", "Symbola", "DejaVu Sans", system; position: relative; }
-.card.unknown { cursor: default; color: #aaa; }
-.card .card-label { display: none; }
-.always-show-labels .card .card-label, .card:hover .card-label { display: inline-block; position: absolute; font-size: initial; left: 0.6em; bottom: 1.4em; z-index: 1; background: inherit; }
-.card.svg { background: transparent; }
-.always-show-labels .card.svg .card-label, .card.svg:hover .card-label { display: inline-block; position: absolute; font-size: initial; left: 0.1em; bottom: 2em; z-index: 1; background: transparent; }
+.card { font-size: 8em; display: inline-block; cursor: pointer; margin-right: -0.35em; background: transparent; user-select: none; font-family: "Noto Sans", "Segoe UI Symbol", "Symbola", "DejaVu Sans", system; position: relative; }
+.unknown, .card.unknown { cursor: default; color: #aaa; }
+.card .card-label { display: none; position: absolute; font-size: initial; left: 0.25em; bottom: 2em; z-index: 1; background: #fff; width: 1.5em; }
+.more .card .card-label { bottom: 1.5em; }
+.always-show-labels .card .card-label, .card:hover .card-label { display: inline-block; }
 .hand .unselected-cards.unclickable .card { cursor: default; }
-.hand .unselected-cards .card.svg:hover .card-label { display: inline-block; position: absolute; font-size: initial; left: 0.1em; bottom: 3.5em; z-index: 1; background: inherit; }
+.hand .unselected-cards .card { margin-top: 0.2em; }
+.hand .unselected-cards .card:hover canvas, .hand .unselected-cards .card.selected canvas { transform: translateY(-0.15em); }
 .hand .unselected-cards .card:hover svg { margin-bottom: 0.2em; margin-top: -0.2em; }
+.hand .unselected-cards .card:hover .card-label, .hand .unselected-cards .card.selected .card-label { bottom: 3.2em; }
+.always-show-labels .card.svg .card-label, .card.svg:hover .card-label { left: 0.1em; bottom: 0.4em; }
+.hand .unselected-cards .card.svg:hover .card-label { left: 0.1em; bottom: 2em; }
 .ReactModal__Overlay { z-index: 2; }
 .notify .card, .card.notify { animation:blinkingText 1.5s 1; color: #000; }
 @keyframes blinkingText {
@@ -29,13 +32,13 @@ button.normal { padding: 2px; cursor: pointer; margin: 2px; line-height: 1em; }
 .♧ { color: #000; }
 .🃟 { color: #000; }
 .🃏 { color: #bb0313; }
-.points .card { font-size: 5em; cursor: default; }
-.four-color .♢ { color: #1933f9; }
-.four-color .♡ { color: #bb0313; }
-.four-color .♤ { color: #000; }
-.four-color .♧ { color: #477e1b; }
-.four-color .🃟 { color: #000; }
-.four-color .🃏 { color: #bb0313; }
+.points .card { cursor: default; }
+.four-color .♢, .four-color.♢ { color: #1933f9; }
+.four-color .♡, .four-color.♡ { color: #bb0313; }
+.four-color .♤, .four-color.♤ { color: #000; }
+.four-color .♧, .four-color.♧ { color: #477e1b; }
+.four-color .🃟, .four-color.🃟 { color: #000; }
+.four-color .🃏, .four-color.🃏 { color: #bb0313; }
 .hand p { margin: 0; text-align: center; }
 .hand .unselected-cards { padding: 0 10px; }
 .hand .selected-cards { padding: 0 10px; }
@@ -56,7 +59,7 @@ button.normal { padding: 2px; cursor: pointer; margin: 2px; line-height: 1em; }
 .labeled-play.clickable .card { cursor: pointer; }
 .labeled-play.winning { box-shadow: inset 0px 0px 0px 2px #bb0313; }
 .labeled-play .more .card { font-size: 6em; }
-.always-show-labels .more .card.svg .card-label, .more .card.svg:hover .card-label { bottom: 1.5em; }
+.always-show-labels .more .card.svg .card-label, .more .card.svg:hover .card-label { bottom: 0em; }
 .labeled-play .play { display: inline-block; }
 .trump { margin: 10px 0; }
 .pending-friends p { margin: 0; }

--- a/frontend/static/style.css
+++ b/frontend/static/style.css
@@ -6,7 +6,7 @@ button.normal { padding: 2px; cursor: pointer; margin: 2px; line-height: 1em; }
 .player { border: 1px #000 solid; padding: 10px; line-height: 1em; }
 .errors { position: fixed; z-index: 100; background: #f00; color: #fff; padding: 0 10px; }
 .trick { padding: 10px; }
-.card { font-size: 8em; display: inline-block; cursor: pointer; margin-right: -0.35em; background: transparent; user-select: none; font-family: "Noto Sans", "Segoe UI Symbol", "Symbola", "DejaVu Sans", system; position: relative; }
+.card { font-size: 8em; display: inline-block; cursor: pointer; margin-right: -0.35em; background: transparent; user-select: none; font-family: "Apple Symbols", "Segoe UI Symbol", "Symbola", "DejaVu Sans", system; position: relative; }
 .card > svg { background: #fff; margin-left: 1px; }
 .card:first-child > svg { padding: 0; }
 .unknown, .card.unknown { cursor: default; color: #aaa; }

--- a/frontend/static/style.css
+++ b/frontend/static/style.css
@@ -7,7 +7,7 @@ button.normal { padding: 2px; cursor: pointer; margin: 2px; line-height: 1em; }
 .errors { position: fixed; z-index: 100; background: #f00; color: #fff; padding: 0 10px; }
 .trick { padding: 10px; }
 .card { font-size: 8em; display: inline-block; cursor: pointer; margin-right: -0.35em; background: transparent; user-select: none; font-family: "Noto Sans", "Segoe UI Symbol", "Symbola", "DejaVu Sans", system; position: relative; }
-.card > svg { background: #fff; padding-left: 2px; }
+.card > svg { background: #fff; margin-left: 1px; }
 .card:first-child > svg { padding: 0; }
 .unknown, .card.unknown { cursor: default; color: #aaa; }
 .card .card-label { display: none; position: absolute; font-size: initial; left: 0.35em; bottom: 2.2em; z-index: 1; background: #fff; width: 1.5em; }
@@ -46,7 +46,7 @@ button.normal { padding: 2px; cursor: pointer; margin: 2px; line-height: 1em; }
 .hand .selected-cards { padding: 0 10px; }
 .next { color: blue; font-weight: bold; }
 .landlord { background: #ddd; }
-.landlord .card { background: #ddd; }
+.landlord .card svg { background: #ddd; }
 .observer { border: 1px #222 dashed; color: #222; }
 .chat { min-width: 225px; width: 20%; border: 1px #eee solid; float: right; margin-top: 20px; }
 .game { min-width: 690px; min-height: 660px; width: 70%; display: inline-block; }
@@ -57,7 +57,7 @@ button.normal { padding: 2px; cursor: pointer; margin: 2px; line-height: 1em; }
 .labeled-play { display: inline-block; padding: 10px; border: 1px solid #000; }
 .labeled-play .label { text-align: center; line-height: 1em; }
 .labeled-play .card-group { display: inline-block; }
-.labeled-play .card { cursor: default; margin-top: 0.2em; }
+.labeled-play .card { cursor: default; }
 .labeled-play.clickable .card { cursor: pointer; }
 .labeled-play.winning { box-shadow: inset 0px 0px 0px 2px #bb0313; }
 .labeled-play .more .card { font-size: 6em; }

--- a/frontend/static/style.css
+++ b/frontend/static/style.css
@@ -1,4 +1,4 @@
-body { font-family: sans-serif; font-size: 95%; margin: 0 20px; }
+body { font-family: sans-serif; margin: 0 20px; }
 button { padding: 10px; cursor: pointer; margin: 10px; line-height: 1em; }
 button.normal { padding: 2px; cursor: pointer; margin: 2px; line-height: 1em; }
 .emoji-picker-react button { margin: 0; }
@@ -7,17 +7,19 @@ button.normal { padding: 2px; cursor: pointer; margin: 2px; line-height: 1em; }
 .errors { position: fixed; z-index: 100; background: #f00; color: #fff; padding: 0 10px; }
 .trick { padding: 10px; }
 .card { font-size: 8em; display: inline-block; cursor: pointer; margin-right: -0.35em; background: transparent; user-select: none; font-family: "Noto Sans", "Segoe UI Symbol", "Symbola", "DejaVu Sans", system; position: relative; }
+.card > svg { background: #fff; padding-left: 2px; }
+.card:first-child > svg { padding: 0; }
 .unknown, .card.unknown { cursor: default; color: #aaa; }
-.card .card-label { display: none; position: absolute; font-size: initial; left: 0.25em; bottom: 2em; z-index: 1; background: #fff; width: 1.5em; }
-.more .card .card-label { bottom: 1.5em; }
-.always-show-labels .card .card-label, .card:hover .card-label { display: inline-block; }
+.card .card-label { display: none; position: absolute; font-size: initial; left: 0.35em; bottom: 2.2em; z-index: 1; background: #fff; width: 1.5em; }
+.more .card .card-label { bottom: 1.85em; }
 .hand .unselected-cards.unclickable .card { cursor: default; }
 .hand .unselected-cards .card { margin-top: 0.2em; }
-.hand .unselected-cards .card:hover canvas, .hand .unselected-cards .card.selected canvas { transform: translateY(-0.15em); }
-.hand .unselected-cards .card:hover svg { margin-bottom: 0.2em; margin-top: -0.2em; }
-.hand .unselected-cards .card:hover .card-label, .hand .unselected-cards .card.selected .card-label { bottom: 3.2em; }
-.always-show-labels .card.svg .card-label, .card.svg:hover .card-label { left: 0.1em; bottom: 0.4em; }
-.hand .unselected-cards .card.svg:hover .card-label { left: 0.1em; bottom: 2em; }
+.hand .unselected-cards .card:hover svg { transform: translateY(-0.15em); }
+.hand .unselected-cards .card:hover .card-label { bottom: 3.45em }
+.hand .unselected-cards .card.svg:hover svg { margin-bottom: 0.2em; margin-top: -0.2em; }
+.hand .unselected-cards .card.svg:hover .card-label { left: 0.15em; bottom: 5em; }
+.always-show-labels .card .card-label, .card:hover .card-label { display: inline-block; }
+.always-show-labels .card.svg .card-label, .card.svg:hover .card-label { left: 0.15em; bottom: 2.2em; }
 .ReactModal__Overlay { z-index: 2; }
 .notify .card, .card.notify { animation:blinkingText 1.5s 1; color: #000; }
 @keyframes blinkingText {
@@ -55,12 +57,13 @@ button.normal { padding: 2px; cursor: pointer; margin: 2px; line-height: 1em; }
 .labeled-play { display: inline-block; padding: 10px; border: 1px solid #000; }
 .labeled-play .label { text-align: center; line-height: 1em; }
 .labeled-play .card-group { display: inline-block; }
-.labeled-play .card { cursor: default; }
+.labeled-play .card { cursor: default; margin-top: 0.2em; }
 .labeled-play.clickable .card { cursor: pointer; }
 .labeled-play.winning { box-shadow: inset 0px 0px 0px 2px #bb0313; }
 .labeled-play .more .card { font-size: 6em; }
-.always-show-labels .more .card.svg .card-label, .more .card.svg:hover .card-label { bottom: 0em; }
+.always-show-labels .more .card.svg .card-label, .more .card.svg:hover .card-label { bottom: 1.8em; }
 .labeled-play .play { display: inline-block; }
+.labeled-play .play + .play { margin-left: 10px; }
 .trump { margin: 10px 0; }
 .pending-friends p { margin: 0; }
 .pending-friends { margin: 10px; }


### PR DESCRIPTION
Use Canvas text-bounding-box utilities to more accurately place the card character where it's supposed to be. Manually tested on Windows and MacOS default system fonts.

This will probably regress render performance a bit, but in exchange for allow the raise-on-hover functionality.

In order to not look weird on HiDPI screens, do the actual rendering via SVG tricks rather than canvas tricks. web tech is absurd