### PR TITLE
Use WASM to sort and group cards from the hands structure

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -119,7 +119,6 @@ pub enum UserMessage {
 pub enum GameMessage {
     State {
         state: game_state::GameState,
-        cards: Vec<types::Card>,
     },
     Message {
         from: String,
@@ -409,8 +408,8 @@ async fn user_connected(ws: WebSocket, games: Games, stats: Arc<Mutex<InMemorySt
 
             // send the updated game state to everyone!
             for user in game.users.values() {
-                if let Ok((state, cards)) = game.game.dump_state_for_player(user.player_id) {
-                    user.send(&GameMessage::State { state, cards });
+                if let Ok(state) = game.game.dump_state_for_player(user.player_id) {
+                    user.send(&GameMessage::State { state });
                 }
 
                 for (data, message) in &msgs {
@@ -488,10 +487,10 @@ async fn user_connected(ws: WebSocket, games: Games, stats: Arc<Mutex<InMemorySt
                             for user in game.users.values() {
                                 if user.player_id == id {
                                     user.send(&GameMessage::Kicked);
-                                } else if let Ok((state, cards)) =
+                                } else if let Ok(state) =
                                     game.game.dump_state_for_player(user.player_id)
                                 {
-                                    user.send(&GameMessage::State { state, cards });
+                                    user.send(&GameMessage::State { state });
                                 }
                                 for (data, message) in &msgs {
                                     user.send(&GameMessage::Broadcast {
@@ -515,16 +514,14 @@ async fn user_connected(ws: WebSocket, games: Games, stats: Arc<Mutex<InMemorySt
                         Ok(msgs) => {
                             // send the updated game state to everyone!
                             for user in game.users.values() {
-                                if let Ok((state, cards)) =
-                                    game.game.dump_state_for_player(user.player_id)
-                                {
+                                if let Ok(state) = game.game.dump_state_for_player(user.player_id) {
                                     for (data, message) in &msgs {
                                         user.send(&GameMessage::Broadcast {
                                             data: data.clone(),
                                             message: message.clone(),
                                         });
                                     }
-                                    user.send(&GameMessage::State { state, cards });
+                                    user.send(&GameMessage::State { state });
                                 }
                             }
                         }

--- a/core/src/game_state.rs
+++ b/core/src/game_state.rs
@@ -750,32 +750,6 @@ impl GameState {
         bail!("Couldn't find player id")
     }
 
-    pub fn cards(&self, id: PlayerID) -> Vec<Card> {
-        match self {
-            GameState::Initialize { .. } => vec![],
-            GameState::Draw(DrawPhase {
-                ref hands,
-                ref propagated,
-                ..
-            }) => {
-                let level_id = propagated.landlord.unwrap_or(id);
-                propagated
-                    .players
-                    .iter()
-                    .filter(|p| p.id == level_id)
-                    .flat_map(|p| hands.cards(id, p.level).ok())
-                    .next()
-                    .unwrap_or_default()
-            }
-            GameState::Exchange(ExchangePhase {
-                ref hands, trump, ..
-            })
-            | GameState::Play(PlayPhase {
-                ref hands, trump, ..
-            }) => hands.cards(id, trump.number()).unwrap_or_else(|_| vec![]),
-        }
-    }
-
     pub fn register(&mut self, name: String) -> Result<(PlayerID, Vec<MessageVariant>), Error> {
         if let Ok(pid) = self.player_id(&name) {
             return Ok((

--- a/core/src/interactive.rs
+++ b/core/src/interactive.rs
@@ -48,8 +48,8 @@ impl InteractiveGame {
         self.state.game_shadowing_policy == GameShadowingPolicy::AllowMultipleSessions
     }
 
-    pub fn dump_state_for_player(&self, id: PlayerID) -> Result<(GameState, Vec<Card>), Error> {
-        Ok((self.state.for_player(id), self.state.cards(id)))
+    pub fn dump_state_for_player(&self, id: PlayerID) -> Result<GameState, Error> {
+        Ok(self.state.for_player(id))
     }
 
     pub fn next_player(&self) -> Result<PlayerID, Error> {

--- a/frontend/src/AppStateProvider.tsx
+++ b/frontend/src/AppStateProvider.tsx
@@ -14,7 +14,6 @@ export interface AppState {
   roomName: string;
   name: string;
   game_state: IGameState | null;
-  cards: string[];
   errors: string[];
   messages: IMessage[];
   confetti: string | null;
@@ -28,7 +27,6 @@ const appState: State<AppState> = combineState({
   roomName: noPersistence(() => window.location.hash.slice(1)),
   name: stringLocalStorageState("name"),
   game_state: noPersistence(() => null),
-  cards: noPersistence(() => []),
   errors: noPersistence(() => []),
   messages: noPersistence(() => []),
   confetti: noPersistence(() => null),

--- a/frontend/src/Card.tsx
+++ b/frontend/src/Card.tsx
@@ -13,6 +13,8 @@ interface IProps {
   smaller?: boolean;
   className?: string;
   onClick?: (event: React.MouseEvent) => void;
+  onMouseEnter?: (event: React.MouseEvent) => void;
+  onMouseLeave?: (event: React.MouseEvent) => void;
 }
 
 const Card = (props: IProps): JSX.Element => {
@@ -51,6 +53,8 @@ const Card = (props: IProps): JSX.Element => {
       <span
         className={classNames("card", cardInfo.typ, props.className)}
         onClick={props.onClick}
+        onMouseEnter={props.onMouseEnter}
+        onMouseLeave={props.onMouseLeave}
       >
         <div className="card-label">
           <InlineCard card={props.card} />
@@ -72,6 +76,8 @@ const Card = (props: IProps): JSX.Element => {
           <span
             className={classNames("card", "svg", cardInfo.typ, props.className)}
             onClick={props.onClick}
+            onMouseEnter={props.onMouseEnter}
+            onMouseLeave={props.onMouseLeave}
           >
             <div className="card-label">
               <InlineCard card={props.card} />

--- a/frontend/src/Cards.tsx
+++ b/frontend/src/Cards.tsx
@@ -1,19 +1,38 @@
 import * as React from "react";
-import Card from "./Card";
 import classNames from "classnames";
+import Card from "./Card";
+import { ITrump, IHands } from "./types";
 import ArrayUtils from "./util/array";
+import WasmContext from "./WasmContext";
+import { SettingsContext } from "./AppStateProvider";
 
 interface IProps {
-  cardsInHand: string[];
+  hands: IHands;
+  trump: ITrump;
+  playerId: number;
   selectedCards?: string[];
   onSelect?: (selected: string[]) => void;
+  onCardClick?: (card: string) => void;
   notifyEmpty?: boolean;
 }
 
 const Cards = (props: IProps): JSX.Element => {
-  const { cardsInHand, selectedCards, notifyEmpty } = props;
+  const [highlightedSuit, setHighlightedSuit] = React.useState<string | null>(
+    null
+  );
+
+  const { hands, selectedCards, notifyEmpty } = props;
+  const { sortAndGroupCards } = React.useContext(WasmContext);
+  const {
+    separateCardsBySuit,
+    disableSuitHighlights,
+    reverseCardOrder,
+  } = React.useContext(SettingsContext);
   const handleSelect = (card: string) => () => {
-    if (selectedCards !== undefined) {
+    if (props.onCardClick !== undefined) {
+      props.onCardClick(card);
+    }
+    if (selectedCards !== undefined && props.onSelect !== undefined) {
       props.onSelect([...selectedCards, card]);
     }
   };
@@ -27,35 +46,96 @@ const Cards = (props: IProps): JSX.Element => {
     }
   };
 
+  const cardsInHand =
+    props.playerId in hands.hands
+      ? Object.entries(hands.hands[props.playerId]).flatMap(([c, ct]) =>
+          Array(ct).fill(c)
+        )
+      : [];
+
   const unselected =
     selectedCards === undefined
       ? cardsInHand
       : ArrayUtils.minus(cardsInHand, selectedCards);
+
+  let selectedCardGroups =
+    props.selectedCards !== undefined
+      ? sortAndGroupCards({
+          cards: props.selectedCards,
+          trump: props.trump,
+        }).map((g) =>
+          g.cards.map((c) => ({
+            card: c,
+            suit: g.suit,
+          }))
+        )
+      : [];
+
+  let unselectedCardGroups = sortAndGroupCards({
+    cards: unselected,
+    trump: props.trump,
+  }).map((g) =>
+    g.cards.map((c) => ({
+      card: c,
+      suit: g.suit,
+    }))
+  );
+
+  if (!separateCardsBySuit) {
+    selectedCardGroups = [selectedCardGroups.flatMap((g) => g)];
+    unselectedCardGroups = [unselectedCardGroups.flatMap((g) => g)];
+  }
+
+  if (reverseCardOrder) {
+    unselectedCardGroups.reverse();
+    unselectedCardGroups.forEach((g) => g.reverse());
+  }
+
   return (
     <div className="hand">
       {props.selectedCards !== undefined ? (
         <div className="selected-cards">
-          {selectedCards.map((c, idx) => (
-            <Card key={idx} onClick={handleUnselect(c)} card={c} />
+          {selectedCardGroups.map((g, gidx) => (
+            <div style={{ display: "inline-block" }} key={gidx}>
+              {g.map((c, idx) => (
+                <Card
+                  key={`${gidx}-${idx}`}
+                  onClick={handleUnselect(c.card)}
+                  card={c.card}
+                />
+              ))}
+            </div>
           ))}
-          {selectedCards.length === 0 && (
+          {props.selectedCards.length === 0 && (
             <Card card="🂠" className={classNames({ notify: notifyEmpty })} />
           )}
         </div>
       ) : null}
       <div
         className={classNames("unselected-cards", {
-          unclickable: props.onSelect === undefined,
+          unclickable:
+            props.onSelect === undefined && props.onCardClick === undefined,
         })}
       >
-        {unselected.map((c, idx) => (
-          <Card
-            key={idx}
-            onClick={props.onSelect !== undefined ? handleSelect(c) : null}
-            card={c}
-          />
+        {unselectedCardGroups.map((g, gidx) => (
+          <div style={{ display: "inline-block" }} key={gidx}>
+            {g.map((c, idx) => (
+              <Card
+                key={`${gidx}-${idx}`}
+                className={classNames(
+                  !disableSuitHighlights && highlightedSuit === c.suit
+                    ? "highlighted"
+                    : null
+                )}
+                onClick={handleSelect(c.card)}
+                card={c.card}
+                onMouseEnter={(evt) => setHighlightedSuit(c.suit)}
+                onMouseLeave={(evt) => setHighlightedSuit(null)}
+              />
+            ))}
+          </div>
         ))}
-        {unselected.length === 0 && <Card card="🂠" />}
+        {unselectedCardGroups.length === 0 && <Card card="🂠" />}
       </div>
     </div>
   );

--- a/frontend/src/Draw.tsx
+++ b/frontend/src/Draw.tsx
@@ -10,7 +10,6 @@ import BidArea from "./BidArea";
 interface IDrawProps {
   state: IDrawPhase;
   name: string;
-  cards: string[];
   setTimeout: (fn: () => void, timeout: number) => number;
   clearTimeout: (id: number) => void;
 }
@@ -120,7 +119,6 @@ class Draw extends React.Component<IDrawProps, IDrawState> {
         <BidArea
           bids={this.props.state.bids}
           autobid={this.props.state.autobid}
-          cards={this.props.cards}
           hands={this.props.state.hands}
           epoch={0}
           name={this.props.name}
@@ -196,7 +194,11 @@ class Draw extends React.Component<IDrawProps, IDrawState> {
             "AllowBidTakeback"
           }
         />
-        <LabeledPlay cards={this.props.state.kitty} label="底牌" />
+        <LabeledPlay
+          className="kitty"
+          cards={this.props.state.kitty}
+          label="底牌"
+        />
       </div>
     );
   }

--- a/frontend/src/Exchange.tsx
+++ b/frontend/src/Exchange.tsx
@@ -9,11 +9,11 @@ import Friends from "./Friends";
 import Players from "./Players";
 import LabeledPlay from "./LabeledPlay";
 import { IExchangePhase, IFriend } from "./types";
+import Cards from "./Cards";
 
 interface IExchangeProps {
   state: IExchangePhase;
   name: string;
-  cards: string[];
 }
 interface IExchangeState {
   friends: IFriend[];
@@ -121,7 +121,7 @@ class Exchange extends React.Component<IExchangeProps, IExchangeState> {
 
     let landlordIdx = 0;
     let exchangerIdx = 0;
-    let playerId = 0;
+    let playerId = -1;
     this.props.state.propagated.players.forEach((player, idx) => {
       if (player.id === this.props.state.landlord) {
         landlordIdx = idx;
@@ -146,15 +146,12 @@ class Exchange extends React.Component<IExchangeProps, IExchangeState> {
       isExchanger && !this.props.state.finalized ? (
         <>
           <h2>Your hand</h2>
-          <div className="hand">
-            {this.props.cards.map((c, idx) => (
-              <Card
-                key={idx}
-                onClick={() => this.moveCardToKitty(c)}
-                card={c}
-              />
-            ))}
-          </div>
+          <Cards
+            hands={this.props.state.hands}
+            playerId={playerId}
+            onCardClick={(c) => this.moveCardToKitty(c)}
+            trump={this.props.state.trump}
+          />
           <h2>
             Discarded cards {this.props.state.kitty.length} /{" "}
             {this.props.state.kitty_size}
@@ -200,7 +197,6 @@ class Exchange extends React.Component<IExchangeProps, IExchangeState> {
           <BidArea
             bids={this.props.state.bids}
             autobid={this.props.state.autobid}
-            cards={this.props.cards}
             hands={this.props.state.hands}
             epoch={this.props.state.epoch}
             name={this.props.name}
@@ -229,7 +225,11 @@ class Exchange extends React.Component<IExchangeProps, IExchangeState> {
               "AllowBidTakeback"
             }
           />
-          <LabeledPlay cards={this.props.state.kitty} label="底牌" />
+          <LabeledPlay
+            className="kitty"
+            cards={this.props.state.kitty}
+            label="底牌"
+          />
         </>
       ) : null;
     const friendUI =
@@ -276,13 +276,13 @@ class Exchange extends React.Component<IExchangeProps, IExchangeState> {
         <Trump trump={this.props.state.trump} />
         {friendUI}
         {exchangeUI}
-        {exchangeUI === null && bidUI === null ? (
+        {exchangeUI === null && bidUI === null && playerId >= 0 ? (
           <>
-            <div className="hand">
-              {this.props.cards.map((c, idx) => (
-                <Card key={idx} card={c} />
-              ))}
-            </div>
+            <Cards
+              hands={this.props.state.hands}
+              playerId={playerId}
+              trump={this.props.state.trump}
+            />
             <p>Waiting...</p>
           </>
         ) : null}

--- a/frontend/src/Initialize.tsx
+++ b/frontend/src/Initialize.tsx
@@ -315,7 +315,6 @@ const UncommonSettings = (props: IUncommonSettings): JSX.Element => {
 
 interface IProps {
   state: IInitializePhase;
-  cards: string[];
   name: string;
 }
 

--- a/frontend/src/Play.tsx
+++ b/frontend/src/Play.tsx
@@ -17,7 +17,6 @@ import { WebsocketContext } from "./WebsocketProvider";
 interface IProps {
   playPhase: IPlayPhase;
   name: string;
-  cards: string[];
   beepOnTurn: boolean;
   showLastTrick: boolean;
   unsetAutoPlayWhenWinnerChanges: boolean;
@@ -140,7 +139,9 @@ const Play = (props: IProps): JSX.Element => {
       {canFinish && <button onClick={startNewGame}>Finish game</button>}
       <BeepButton />
       <Cards
-        cardsInHand={props.cards}
+        hands={playPhase.hands}
+        playerId={currentPlayer.id}
+        trump={playPhase.trump}
         selectedCards={selected}
         onSelect={setSelected}
         notifyEmpty={isCurrentPlayerTurn}
@@ -171,7 +172,7 @@ const Play = (props: IProps): JSX.Element => {
         hideLandlordPoints={playPhase.propagated.hide_landlord_points}
         bonusLevel={bonusLevel}
       />
-      <LabeledPlay cards={playPhase.kitty} label="底牌" />
+      <LabeledPlay className="kitty" cards={playPhase.kitty} label="底牌" />
     </div>
   );
 };

--- a/frontend/src/Root.tsx
+++ b/frontend/src/Root.tsx
@@ -42,10 +42,6 @@ const Root = (): JSX.Element => {
         </div>
       );
     } else {
-      const cards = [...state.cards];
-      if (state.settings.reverseCardOrder) {
-        cards.reverse();
-      }
       return (
         <div
           className={classNames(
@@ -80,30 +76,23 @@ const Root = (): JSX.Element => {
             {state.game_state.Initialize !== undefined ? (
               <Initialize
                 state={state.game_state.Initialize}
-                cards={cards}
                 name={state.name}
               />
             ) : null}
             {state.game_state.Draw !== undefined ? (
               <Draw
                 state={state.game_state.Draw}
-                cards={cards}
                 name={state.name}
                 setTimeout={timerContext.setTimeout}
                 clearTimeout={timerContext.clearTimeout}
               />
             ) : null}
             {state.game_state.Exchange !== undefined ? (
-              <Exchange
-                state={state.game_state.Exchange}
-                cards={cards}
-                name={state.name}
-              />
+              <Exchange state={state.game_state.Exchange} name={state.name} />
             ) : null}
             {state.game_state.Play !== undefined ? (
               <Play
                 playPhase={state.game_state.Play}
-                cards={cards}
                 name={state.name}
                 showLastTrick={state.settings.showLastTrick}
                 unsetAutoPlayWhenWinnerChanges={

--- a/frontend/src/SettingsPane.tsx
+++ b/frontend/src/SettingsPane.tsx
@@ -128,6 +128,32 @@ const SettingsPane = (props: IProps): JSX.Element => {
           </Cell>
         </Row>
         <Row>
+          <LabelCell>separate cards by effective suit (in hand)</LabelCell>
+          <Cell>
+            <input
+              name="separate-cards-by-suit"
+              type="checkbox"
+              checked={settings.separateCardsBySuit}
+              onChange={handleChange({
+                separateCardsBySuit: !settings.separateCardsBySuit,
+              })}
+            />
+          </Cell>
+        </Row>
+        <Row>
+          <LabelCell>disable suit highlights</LabelCell>
+          <Cell>
+            <input
+              name="disable-suit-highlights"
+              type="checkbox"
+              checked={settings.disableSuitHighlights}
+              onChange={handleChange({
+                disableSuitHighlights: !settings.disableSuitHighlights,
+              })}
+            />
+          </Cell>
+        </Row>
+        <Row>
           <LabelCell>unset auto-play if winner changes</LabelCell>
           <Cell>
             <input

--- a/frontend/src/WasmContext.tsx
+++ b/frontend/src/WasmContext.tsx
@@ -4,6 +4,9 @@ import { ITrump, ITrickUnit, IBid, IHands, IPlayer, BidPolicy } from "./types";
 interface Context {
   findViablePlays: (trump: ITrump, cards: string[]) => ITrickUnit[][];
   findValidBids: (req: IFindValidBidsRequest) => IBid[];
+  sortAndGroupCards: (
+    req: ISortAndGroupCardsRequest
+  ) => ISortedAndGroupedCards[];
 }
 
 interface IFindValidBidsRequest {
@@ -16,9 +19,20 @@ interface IFindValidBidsRequest {
   bid_policy: BidPolicy;
 }
 
+interface ISortAndGroupCardsRequest {
+  trump: ITrump | null;
+  cards: string[];
+}
+
+interface ISortedAndGroupedCards {
+  suit: string;
+  cards: string[];
+}
+
 export const WasmContext = React.createContext<Context>({
   findViablePlays: (trump, cards) => [],
   findValidBids: (req) => [],
+  sortAndGroupCards: (req) => [],
 });
 
 export default WasmContext;

--- a/frontend/src/WasmProvider.tsx
+++ b/frontend/src/WasmProvider.tsx
@@ -17,6 +17,9 @@ const ShengjiProvider = (props: IProps): JSX.Element => {
         findValidBids: (req) => {
           return Shengji.find_valid_bids(req).results;
         },
+        sortAndGroupCards: (req) => {
+          return Shengji.sort_and_group_cards(req).results;
+        },
       }}
     >
       {props.children}

--- a/frontend/src/state/Settings.ts
+++ b/frontend/src/state/Settings.ts
@@ -9,6 +9,8 @@ export interface Settings {
   reverseCardOrder: boolean;
   unsetAutoPlayWhenWinnerChanges: boolean;
   showTrickInPlayerOrder: boolean;
+  separateCardsBySuit: boolean;
+  disableSuitHighlights: boolean;
   svgCards: boolean;
 }
 
@@ -30,6 +32,12 @@ const unsetAutoPlayWhenWinnerChanges: State<boolean> = booleanLocalStorageState(
 const showTrickInPlayerOrder: State<boolean> = booleanLocalStorageState(
   "show_trick_in_player_order"
 );
+const separateCardsBySuit: State<boolean> = booleanLocalStorageState(
+  "separate_cards_by_suit"
+);
+const disableSuitHighlights: State<boolean> = booleanLocalStorageState(
+  "disable_suit_highlights"
+);
 const settings: State<Settings> = combineState({
   fourColor,
   showCardLabels,
@@ -39,6 +47,8 @@ const settings: State<Settings> = combineState({
   unsetAutoPlayWhenWinnerChanges,
   showTrickInPlayerOrder,
   svgCards,
+  separateCardsBySuit,
+  disableSuitHighlights,
 });
 
 export default settings;

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -56,6 +56,11 @@ button.normal {
   position: relative;
 }
 
+.card.highlighted {
+  border-bottom: 1px solid;
+  margin-bottom: -1px;
+}
+
 .card > svg {
   background: #fff;
   margin-left: 1px;
@@ -110,6 +115,10 @@ button.normal {
 .hand .unselected-cards .card.svg:hover .card-label {
   left: 0.15em;
   bottom: 5.4em;
+}
+
+.kitty {
+  margin-top: 40px;
 }
 
 .always-show-labels .card .card-label,

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -16,7 +16,6 @@ export interface IGameMessageBroadcast {
 }
 export interface IGameMessageState {
   state: IGameState;
-  cards: string[];
 }
 export interface IBroadcastMessage {
   actor: number;
@@ -224,9 +223,9 @@ export interface IOrderedCard {
 export type ITrump =
   | {
       Standard: { suit: string; number: string };
-      NoTrump: null;
+      NoTrump?: null;
     }
   | {
-      Standard: null;
+      Standard?: null;
       NoTrump: { number: string };
     };

--- a/frontend/src/websocketHandler.ts
+++ b/frontend/src/websocketHandler.ts
@@ -60,7 +60,7 @@ const stateHandler: WebsocketHandler = (
   message: IGameMessageUnion
 ) => {
   if (message.State !== undefined) {
-    return { game_state: message.State.state, cards: message.State.cards };
+    return { game_state: message.State.state };
   } else {
     return null;
   }


### PR DESCRIPTION
Rather than encoding cards twice (in a fairly expensive way!) on the
wire, use code in the frontend to generate the appropriate list-of-cards
format. Previously, we didn't do this because the sort order of the
cards was undefined without additional state; now, we can do better by
using logic in WASM to sort.