### PR TITLE
Use WASM to implement a bunch of UI helpers

### DIFF
--- a/core/src/game_state.rs
+++ b/core/src/game_state.rs
@@ -9,7 +9,7 @@ use url::Url;
 use crate::bidding::{Bid, BidPolicy, BidTakebackPolicy};
 use crate::hands::Hands;
 use crate::message::MessageVariant;
-use crate::trick::{ThrowEvaluationPolicy, Trick, TrickDrawPolicy, TrickEnded};
+use crate::trick::{ThrowEvaluationPolicy, Trick, TrickDrawPolicy, TrickEnded, TrickUnit};
 use crate::types::{Card, Number, PlayerID, Trump, FULL_DECK};
 
 macro_rules! bail_unwrap {
@@ -942,12 +942,22 @@ impl PlayPhase {
         id: PlayerID,
         cards: &[Card],
     ) -> Result<Vec<MessageVariant>, Error> {
+        self.play_cards_with_hint(id, cards, None)
+    }
+
+    pub fn play_cards_with_hint(
+        &mut self,
+        id: PlayerID,
+        cards: &[Card],
+        format_hint: Option<&'_ [TrickUnit]>,
+    ) -> Result<Vec<MessageVariant>, Error> {
         let mut msgs = self.trick.play_cards(
             id,
             &mut self.hands,
             cards,
             self.propagated.trick_draw_policy,
             self.propagated.throw_evaluation_policy,
+            format_hint,
         )?;
         if self.propagated.hide_played_cards {
             for msg in &mut msgs {

--- a/core/src/interactive.rs
+++ b/core/src/interactive.rs
@@ -10,7 +10,7 @@ use crate::game_state::{
     ThrowPenalty,
 };
 use crate::message::MessageVariant;
-use crate::trick::{ThrowEvaluationPolicy, TrickDrawPolicy};
+use crate::trick::{ThrowEvaluationPolicy, TrickDrawPolicy, TrickUnit};
 use crate::types::{Card, Number, PlayerID};
 
 pub struct InteractiveGame {
@@ -284,6 +284,13 @@ impl InteractiveGame {
                 debug!(logger, "Playing cards");
                 state.play_cards(id, cards)?
             }
+            (
+                Message::PlayCardsWithHint(ref cards, ref format_hint),
+                GameState::Play(ref mut state),
+            ) => {
+                debug!(logger, "Playing cards with formatting hint");
+                state.play_cards_with_hint(id, cards, Some(format_hint))?
+            }
             (Message::EndTrick, GameState::Play(ref mut state)) => {
                 info!(logger, "Finishing trick");
                 state.finish_trick()?
@@ -367,6 +374,7 @@ pub enum Message {
     SetFriends(Vec<FriendSelection>),
     BeginPlay,
     PlayCards(Vec<Card>),
+    PlayCardsWithHint(Vec<Card>, Vec<TrickUnit>),
     EndTrick,
     TakeBackCards,
     TakeBackBid,

--- a/core/src/trick.rs
+++ b/core/src/trick.rs
@@ -745,15 +745,15 @@ impl UnitLike {
             UnitLike::Tractor {
                 count: 2,
                 length: 2,
-            } => format!("tractor"),
+            } => "tractor".to_string(),
             UnitLike::Tractor { count: 3, length } => format!("{}-tractor of triples", length),
             UnitLike::Tractor { count: 4, length } => format!("{}-tractor of quadruples", length),
             UnitLike::Tractor { count, length } => format!("{} by {} tractor", count, length),
-            UnitLike::Repeated { count: 1 } => format!("single"),
-            UnitLike::Repeated { count: 2 } => format!("pair"),
-            UnitLike::Repeated { count: 3 } => format!("triple"),
-            UnitLike::Repeated { count: 4 } => format!("quadruple"),
-            UnitLike::Repeated { count: 5 } => format!("quintuple"),
+            UnitLike::Repeated { count: 1 } => "single".to_string(),
+            UnitLike::Repeated { count: 2 } => "pair".to_string(),
+            UnitLike::Repeated { count: 3 } => "triple".to_string(),
+            UnitLike::Repeated { count: 4 } => "quadruple".to_string(),
+            UnitLike::Repeated { count: 5 } => "quintuple".to_string(),
             UnitLike::Repeated { count } => format!("{}-tuple", count),
         }
     }
@@ -864,7 +864,7 @@ impl OrderedCard {
         iter.flat_map(|(card, count)| (0..*count).map(move |_| card))
     }
 
-    pub fn cmp_effective(&self, o: OrderedCard) -> Ordering {
+    pub fn cmp_effective(self, o: OrderedCard) -> Ordering {
         self.trump.compare_effective(self.card, o.card)
     }
 }

--- a/frontend/src/AutoPlayButton.tsx
+++ b/frontend/src/AutoPlayButton.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 
 interface IProps {
   onSubmit: () => void;
+  playDescription: null | string;
   canSubmit: boolean;
   currentWinner: number | null;
   isCurrentPlayerTurn: boolean;
@@ -17,6 +18,7 @@ const AutoPlayButton = (props: IProps): JSX.Element => {
     onSubmit,
     canSubmit,
     isCurrentPlayerTurn,
+    playDescription,
     currentWinner,
     unsetAutoPlayWhenWinnerChanges,
   } = props;
@@ -57,7 +59,9 @@ const AutoPlayButton = (props: IProps): JSX.Element => {
   return (
     <button onClick={handleClick} disabled={!canSubmit}>
       {isCurrentPlayerTurn
-        ? "Play selected cards"
+        ? `Play selected cards${
+            playDescription !== null ? " (" + playDescription + ")" : ""
+          }`
         : autoplay !== null
         ? "Don't autoplay selected cards"
         : "Autoplay selected cards"}

--- a/frontend/src/Credits.tsx
+++ b/frontend/src/Credits.tsx
@@ -35,6 +35,16 @@ const ChangeLog = (): JSX.Element => {
             Fix a bug where throws in trump of the trump-rank-card would be
             incorrectly blocked
           </li>
+          <li>
+            Implement helper which lets you know what plays you can make and
+            tells you about format-decompositions
+          </li>
+          <li>
+            Allow player to specify preferred grouping in case of ambiguity,
+            e.g. 22333 as either [22][333] or [2233][3]
+          </li>
+          <li>Add UI hint which shows you cards in the same suit</li>
+          <li>Add UI setting which allows you to separate cards by suit</li>
         </ul>
         <p>7/23/2020:</p>
         <ul>

--- a/frontend/src/Play.tsx
+++ b/frontend/src/Play.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
-import { IPlayPhase } from "./types";
+import * as ReactModal from "react-modal";
+import { IPlayPhase, ITrickFormat, IHands, TrickDrawPolicy } from "./types";
 import Header from "./Header";
 import Beeper from "./Beeper";
 import Trump from "./Trump";
@@ -13,6 +14,15 @@ import ArrayUtils from "./util/array";
 import AutoPlayButton from "./AutoPlayButton";
 import BeepButton from "./BeepButton";
 import { WebsocketContext } from "./WebsocketProvider";
+import WasmContext, { IFoundViablePlay } from "./WasmContext";
+import InlineCard from "./InlineCard";
+
+const contentStyle = {
+  position: "absolute",
+  top: "50%",
+  left: "50%",
+  transform: "translate(-50%, -50%)",
+};
 
 interface IProps {
   playPhase: IPlayPhase;
@@ -26,10 +36,13 @@ interface IProps {
 const Play = (props: IProps): JSX.Element => {
   const { send } = React.useContext(WebsocketContext);
   const [selected, setSelected] = React.useState<string[]>([]);
+  const [grouping, setGrouping] = React.useState<IFoundViablePlay[]>([]);
+  const { findViablePlays, canPlayCards } = React.useContext(WasmContext);
 
   const playCards = (): void => {
-    send({ Action: { PlayCards: selected } });
+    send({ Action: { PlayCardsWithHint: [selected, grouping[0].grouping] } });
     setSelected([]);
+    setGrouping([]);
   };
 
   const sendEvent = (event: {}) => () => send(event);
@@ -41,6 +54,7 @@ const Play = (props: IProps): JSX.Element => {
 
   // TODO: instead of telling who the player is by checking the name, pass in
   // the Player object
+  let isSpectator = true;
   let currentPlayer = playPhase.propagated.players.find(
     (p) => p.name === props.name
   );
@@ -48,16 +62,28 @@ const Play = (props: IProps): JSX.Element => {
     currentPlayer = playPhase.propagated.observers.find(
       (p) => p.name === props.name
     );
+  } else {
+    isSpectator = false;
   }
   const nextPlayer = playPhase.trick.player_queue[0];
   const lastPlay =
     playPhase.trick.played_cards[playPhase.trick.played_cards.length - 1];
 
   const isCurrentPlayerTurn = currentPlayer.id === nextPlayer;
-  const canPlay =
-    lastPlay !== undefined
-      ? selected.length === lastPlay.cards.length
-      : selected.length > 0;
+  let canPlay = false;
+  if (!isSpectator) {
+    canPlay = canPlayCards({
+      trick: playPhase.trick,
+      id: currentPlayer.id,
+      hands: playPhase.hands,
+      cards: selected,
+      trick_draw_policy: playPhase.propagated.trick_draw_policy,
+    });
+    // In order to play the first trick, the grouping must be disambiguated!
+    if (lastPlay === undefined) {
+      canPlay = canPlay && grouping.length === 1;
+    }
+  }
   const canTakeBack =
     lastPlay !== undefined && currentPlayer.id === lastPlay.id;
 
@@ -91,6 +117,7 @@ const Play = (props: IProps): JSX.Element => {
         "BonusLevelForSmallerLandlordTeam" &&
       landlordTeamSize < configFriendTeamSize;
   }
+
   return (
     <div>
       {shouldBeBeeping ? <Beeper /> : null}
@@ -120,6 +147,11 @@ const Play = (props: IProps): JSX.Element => {
       />
       <AutoPlayButton
         onSubmit={playCards}
+        playDescription={
+          grouping.length === 1 && lastPlay === undefined
+            ? grouping[0].description
+            : null
+        }
         canSubmit={canPlay}
         currentWinner={playPhase.trick.current_winner}
         unsetAutoPlayWhenWinnerChanges={props.unsetAutoPlayWhenWinnerChanges}
@@ -138,12 +170,46 @@ const Play = (props: IProps): JSX.Element => {
       </button>
       {canFinish && <button onClick={startNewGame}>Finish game</button>}
       <BeepButton />
+      {playPhase.trick.trick_format !== null &&
+      !isSpectator &&
+      playPhase.trick.player_queue.includes(currentPlayer.id) ? (
+        <TrickFormatHelper
+          format={playPhase.trick.trick_format}
+          hands={playPhase.hands}
+          playerId={currentPlayer.id}
+          trickDrawPolicy={playPhase.propagated.trick_draw_policy}
+        />
+      ) : null}
+      {lastPlay === undefined && isCurrentPlayerTurn && grouping.length > 1 && (
+        <div>
+          <p>
+            It looks like you are making a play that can be interpreted in
+            multiple ways!
+          </p>
+          <p>Which of the following did you mean?</p>
+          {grouping.map((g, gidx) => (
+            <button
+              key={gidx}
+              onClick={(evt) => {
+                evt.preventDefault();
+                setGrouping([g]);
+              }}
+              className="normal"
+            >
+              {g.description}
+            </button>
+          ))}
+        </div>
+      )}
       <Cards
         hands={playPhase.hands}
         playerId={currentPlayer.id}
         trump={playPhase.trump}
         selectedCards={selected}
-        onSelect={setSelected}
+        onSelect={(selected) => {
+          setSelected(selected);
+          setGrouping(findViablePlays(playPhase.trump, selected));
+        }}
         notifyEmpty={isCurrentPlayerTurn}
       />
       {playPhase.last_trick !== undefined &&
@@ -174,6 +240,98 @@ const Play = (props: IProps): JSX.Element => {
       />
       <LabeledPlay className="kitty" cards={playPhase.kitty} label="底牌" />
     </div>
+  );
+};
+
+const TrickFormatHelper = (props: {
+  format: ITrickFormat;
+  hands: IHands;
+  playerId: number;
+  trickDrawPolicy: TrickDrawPolicy;
+}): JSX.Element => {
+  const [modalOpen, setModalOpen] = React.useState<boolean>(false);
+  const { decomposeTrickFormat } = React.useContext(WasmContext);
+  const decomp = decomposeTrickFormat({
+    trick_format: props.format,
+    hands: props.hands,
+    player_id: props.playerId,
+    trick_draw_policy: props.trickDrawPolicy,
+  });
+  const trickSuit = props.format.suit;
+  const bestMatch = decomp.findIndex((d) => d.playable.length > 0);
+
+  return (
+    <>
+      <button
+        onClick={(evt) => {
+          evt.preventDefault();
+          setModalOpen(true);
+        }}
+      >
+        ?
+      </button>
+      <ReactModal
+        isOpen={modalOpen}
+        onRequestClose={() => setModalOpen(false)}
+        shouldCloseOnOverlayClick
+        shouldCloseOnEsc
+        style={{ content: contentStyle }}
+      >
+        <p>
+          In order to win, you have to play {decomp[0].description} in{" "}
+          {trickSuit}
+        </p>
+        {decomp[0].playable.length > 0 && (
+          <p>
+            It looks like you are able to match this format, e.g. with
+            {decomp[0].playable.map((c, cidx) => (
+              <InlineCard key={cidx} card={c} />
+            ))}
+          </p>
+        )}
+
+        {decomp.length > 1 && (
+          <>
+            <p>
+              If you can&apos;t play that, but you <em>can</em> play one of the
+              following, you have to play it
+            </p>
+            <ol>
+              {decomp.slice(1).map((d, idx) => (
+                <li
+                  key={idx}
+                  style={{
+                    fontWeight: idx === bestMatch - 1 ? "bold" : "normal",
+                  }}
+                >
+                  {d.description} in {trickSuit}
+                  {idx === bestMatch - 1 && (
+                    <>
+                      {" "}
+                      (for example:{" "}
+                      {d.playable.map((c, cidx) => (
+                        <InlineCard key={cidx} card={c} />
+                      ))}
+                      )
+                    </>
+                  )}
+                </li>
+              ))}
+            </ol>
+          </>
+        )}
+        <p>
+          Otherwise, you have to play as many {trickSuit} as you can. The
+          remaining cards can be anything.
+        </p>
+        {trickSuit !== "Trump" && (
+          <p>
+            If you have no cards in {trickSuit}, you can play{" "}
+            {decomp[0].description} in Trump to potentially win the trick.
+          </p>
+        )}
+      </ReactModal>
+    </>
   );
 };
 

--- a/frontend/src/WasmContext.tsx
+++ b/frontend/src/WasmContext.tsx
@@ -1,12 +1,32 @@
 import * as React from "react";
-import { ITrump, ITrickUnit, IBid, IHands, IPlayer, BidPolicy } from "./types";
+import {
+  ITrump,
+  ITrickUnit,
+  IBid,
+  IHands,
+  IPlayer,
+  IUnitLike,
+  ITrickFormat,
+  BidPolicy,
+  ITrick,
+  TrickDrawPolicy,
+} from "./types";
 
 interface Context {
-  findViablePlays: (trump: ITrump, cards: string[]) => ITrickUnit[][];
+  findViablePlays: (trump: ITrump, cards: string[]) => IFoundViablePlay[];
   findValidBids: (req: IFindValidBidsRequest) => IBid[];
   sortAndGroupCards: (
     req: ISortAndGroupCardsRequest
   ) => ISortedAndGroupedCards[];
+  decomposeTrickFormat: (
+    req: IDecomposeTrickFormatRequest
+  ) => IDecomposedTrickFormat[];
+  canPlayCards: (req: ICanPlayCardsRequest) => boolean;
+}
+
+export interface IFoundViablePlay {
+  grouping: ITrickUnit[];
+  description: string;
 }
 
 interface IFindValidBidsRequest {
@@ -29,10 +49,33 @@ interface ISortedAndGroupedCards {
   cards: string[];
 }
 
+interface IDecomposedTrickFormat {
+  description: string;
+  format: IUnitLike[];
+  playable: string[];
+}
+
+interface IDecomposeTrickFormatRequest {
+  trick_format: ITrickFormat;
+  hands: IHands;
+  player_id: number;
+  trick_draw_policy: TrickDrawPolicy;
+}
+
+interface ICanPlayCardsRequest {
+  trick: ITrick;
+  id: number;
+  hands: IHands;
+  cards: string[];
+  trick_draw_policy: TrickDrawPolicy;
+}
+
 export const WasmContext = React.createContext<Context>({
   findViablePlays: (trump, cards) => [],
   findValidBids: (req) => [],
   sortAndGroupCards: (req) => [],
+  decomposeTrickFormat: (req) => [],
+  canPlayCards: (req) => false,
 });
 
 export default WasmContext;

--- a/frontend/src/WasmProvider.tsx
+++ b/frontend/src/WasmProvider.tsx
@@ -20,6 +20,12 @@ const ShengjiProvider = (props: IProps): JSX.Element => {
         sortAndGroupCards: (req) => {
           return Shengji.sort_and_group_cards(req).results;
         },
+        decomposeTrickFormat: (req) => {
+          return Shengji.decompose_trick_format(req).results;
+        },
+        canPlayCards: (req) => {
+          return Shengji.can_play_cards(req).playable;
+        },
       }}
     >
       {props.children}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -126,6 +126,7 @@ export interface IPlayPhase {
 }
 
 export type BidPolicy = "JokerOrGreaterLenght" | "GreaterLength";
+export type TrickDrawPolicy = "NoProtections" | "LongerTuplesProtected";
 
 export interface IPropagatedState {
   game_mode: IGameModeSettings;
@@ -145,7 +146,7 @@ export interface IPropagatedState {
   kitty_penalty: "Times" | "Power";
   kitty_bid_policy: "FirstCard" | "FirstCardOfLevelOrHighest";
   throw_penalty: "None" | "TenPointsPerAttempt";
-  trick_draw_policy: "NoProtections" | "LongerTuplesProtected";
+  trick_draw_policy: TrickDrawPolicy;
   throw_evaluation_policy: "All" | "Highest";
   hide_played_cards: boolean;
   landlord_emoji: string | null;
@@ -193,6 +194,7 @@ export interface ITrick {
   played_card_mappings: ICardMapping[];
   current_winner: number | null;
   trump: ITrump;
+  trick_format: ITrickFormat | null;
 }
 
 export interface IPlayedCards {
@@ -211,6 +213,22 @@ export interface ITrickUnit {
   };
   Tractor?: {
     members: IOrderedCard[];
+    count: number;
+  };
+}
+
+export interface ITrickFormat {
+  suit: string;
+  trump: ITrump;
+  units: ITrickUnit[];
+}
+
+export interface IUnitLike {
+  Repeated?: {
+    count: number;
+  };
+  Tractor?: {
+    length: number;
     count: number;
   };
 }


### PR DESCRIPTION
Part of the pathway to #197, fixes #142.

- Allow ambiguity-specification in backend and UI
- Tell you more information about what you're required to play (on
demand)
- Show you cards in the same suit on hover (setting)
- Separate cards by suit (setting)