### PR TITLE
Support custom colors for non-SVG cards

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -59,6 +59,7 @@
     "optimize-css-assets-webpack-plugin": "^5.0.3",
     "prettier": "^2.0.2",
     "prettier-eslint": "^11.0.0",
+    "react-color": "^2.18.1",
     "rimraf": "^3.0.2",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.12"

--- a/frontend/src/Card.tsx
+++ b/frontend/src/Card.tsx
@@ -5,6 +5,7 @@ import memoize from "./memoize";
 import InlineCard from "./InlineCard";
 import { cardLookup } from "./util/cardHelpers";
 import { SettingsContext } from "./AppStateProvider";
+import { ISuitOverrides } from "./state/Settings";
 
 const SvgCard = React.lazy(async () => await import("./SvgCard"));
 
@@ -66,6 +67,9 @@ const Card = (props: IProps): JSX.Element => {
             cardInfo.typ,
             settings.fourColor ? "four-color" : null
           )}
+          colorOverride={
+            settings.suitColorOverrides[cardInfo.typ as keyof ISuitOverrides]
+          }
         />
       </span>
     );
@@ -126,6 +130,7 @@ interface ICardCanvasProps {
   card: string;
   height: number;
   suit: string;
+  colorOverride?: string;
 }
 
 const CardCanvas = (props: ICardCanvasProps): JSX.Element => {
@@ -165,7 +170,7 @@ const CardCanvas = (props: ICardCanvasProps): JSX.Element => {
         height={effectiveHeight}
       ></rect>
       <text
-        fill={style}
+        fill={props.colorOverride !== undefined ? props.colorOverride : style}
         fontSize={`${props.height}px`}
         textLength={`${textMetrics.width}px`}
         x={Math.min(textMetrics.actualBoundingBoxLeft, 0) + 1}

--- a/frontend/src/Credits.tsx
+++ b/frontend/src/Credits.tsx
@@ -29,6 +29,10 @@ const ChangeLog = (): JSX.Element => {
         style={{ content: contentStyle }}
       >
         <h2>Change Log</h2>
+        <p>8/07/2020:</p>
+        <ul>
+          <li>Allow card colors to be customized</li>
+        </ul>
         <p>8/02/2020:</p>
         <ul>
           <li>Support beeps in exchange phase</li>

--- a/frontend/src/InlineCard.tsx
+++ b/frontend/src/InlineCard.tsx
@@ -5,15 +5,26 @@ import {
   ISuitCard,
   unicodeToCard,
 } from "./util/cardHelpers";
+import { SettingsContext } from "./AppStateProvider";
+import { ISuitOverrides } from "./state/Settings";
 
 const InlineCardBase = styled.span`
   padding-left: 0.1em;
   padding-right: 0.1em;
 `;
 
-const Suit = (className: string): React.FunctionComponent<{}> => (props) => (
-  <InlineCardBase className={className} {...props} />
-);
+const Suit = (className: string): React.FunctionComponent<{}> => (props) => {
+  const settings = React.useContext(SettingsContext);
+  return (
+    <InlineCardBase
+      className={className}
+      {...props}
+      style={{
+        color: settings.suitColorOverrides[className as keyof ISuitOverrides],
+      }}
+    />
+  );
+};
 const Diamonds = Suit("♢");
 const Hearts = Suit("♡");
 const Spades = Suit("♤");

--- a/frontend/src/SettingsPane.tsx
+++ b/frontend/src/SettingsPane.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
-import { Settings } from "./state/Settings";
+import { Settings, ISuitOverrides } from "./state/Settings";
+import { CompactPicker } from "react-color";
 import styled from "styled-components";
 
 const Row = styled.div`
@@ -179,6 +180,24 @@ const SettingsPane = (props: IProps): JSX.Element => {
             />
           </Cell>
         </Row>
+        <Row>
+          <LabelCell>suit color overrides</LabelCell>
+          <Cell>
+            {settings.svgCards ? (
+              "disabled with SVG cards"
+            ) : (
+              <SuitOverrides
+                suitColors={settings.suitColorOverrides}
+                setSuitColors={(newOverrides: ISuitOverrides) =>
+                  props.onChangeSettings({
+                    ...props.settings,
+                    suitColorOverrides: newOverrides,
+                  })
+                }
+              />
+            )}
+          </Cell>
+        </Row>
       </div>
       <hr />
       <div style={{ display: "table" }}>
@@ -188,6 +207,72 @@ const SettingsPane = (props: IProps): JSX.Element => {
         </Row>
       </div>
     </div>
+  );
+};
+
+const SuitOverrides = (props: {
+  suitColors: ISuitOverrides;
+  setSuitColors: (overrides: ISuitOverrides) => void;
+}): JSX.Element => {
+  const suits: Array<keyof ISuitOverrides> = ["♢", "♡", "♤", "♧", "🃟", "🃏"];
+  const labels = ["♦", "♥", "♠", "♣", "LJ", "HJ"];
+  return (
+    <>
+      {suits.map((suit, idx) => (
+        <SuitColorPicker
+          key={suit}
+          suit={suit}
+          label={labels[idx]}
+          suitColor={props.suitColors[suit]}
+          setSuitColor={(color: string) => {
+            const n = { ...props.suitColors };
+            n[suit] = color;
+            props.setSuitColors(n);
+          }}
+        />
+      ))}
+      <button
+        className="normal"
+        onClick={(evt) => {
+          evt.preventDefault();
+          props.setSuitColors({});
+        }}
+      >
+        reset
+      </button>
+    </>
+  );
+};
+
+const SuitColorPicker = (props: {
+  suit: string;
+  label: string;
+  suitColor?: string;
+  setSuitColor: (color: string) => void;
+}): JSX.Element => {
+  const [showPicker, setShowPicker] = React.useState<boolean>(false);
+  return (
+    <>
+      <span
+        className={props.suit}
+        style={{ color: props.suitColor, cursor: "pointer" }}
+        onClick={() => setShowPicker(true)}
+      >
+        {props.label}
+      </span>
+      {showPicker ? (
+        <div style={{ position: "absolute" }}>
+          <div
+            style={{ position: "fixed", top: 0, left: 0, right: 0, bottom: 0 }}
+            onClick={() => setShowPicker(false)}
+          />
+          <CompactPicker
+            color={props.suitColor}
+            onChangeComplete={(c: any) => props.setSuitColor(c.hex)}
+          />
+        </div>
+      ) : null}
+    </>
   );
 };
 

--- a/frontend/src/localStorageState.ts
+++ b/frontend/src/localStorageState.ts
@@ -43,3 +43,25 @@ export const numberLocalStorageState = (
       value != null && !isNaN(value) ? parseInt(value, 10) : defaultValue,
     (state: number) => state
   );
+
+export function JSONLocalStorageState<T>(
+  key: string,
+  defaultValue: T
+): State<T> {
+  return localStorageState(
+    key,
+    (value: any): T => {
+      try {
+        const val = JSON.parse(value);
+        if (val !== undefined && val !== null) {
+          return val;
+        } else {
+          return defaultValue;
+        }
+      } catch (e) {
+        return defaultValue;
+      }
+    },
+    (state: T) => JSON.stringify(state)
+  );
+}

--- a/frontend/src/state/Settings.ts
+++ b/frontend/src/state/Settings.ts
@@ -1,5 +1,8 @@
 import { State, combineState } from "../State";
-import { booleanLocalStorageState } from "../localStorageState";
+import {
+  booleanLocalStorageState,
+  JSONLocalStorageState,
+} from "../localStorageState";
 
 export interface Settings {
   fourColor: boolean;
@@ -12,6 +15,17 @@ export interface Settings {
   separateCardsBySuit: boolean;
   disableSuitHighlights: boolean;
   svgCards: boolean;
+  suitColorOverrides: ISuitOverrides;
+}
+
+export interface ISuitOverrides {
+  "♢"?: string;
+  "♡"?: string;
+  "♤"?: string;
+  "♧"?: string;
+  "🃟"?: string;
+  "🃏"?: string;
+  "🂠"?: string;
 }
 
 const fourColor: State<boolean> = booleanLocalStorageState("four_color");
@@ -38,6 +52,10 @@ const separateCardsBySuit: State<boolean> = booleanLocalStorageState(
 const disableSuitHighlights: State<boolean> = booleanLocalStorageState(
   "disable_suit_highlights"
 );
+const suitColorOverrides: State<ISuitOverrides> = JSONLocalStorageState(
+  "suit_color_overrides",
+  {}
+);
 const settings: State<Settings> = combineState({
   fourColor,
   showCardLabels,
@@ -49,6 +67,7 @@ const settings: State<Settings> = combineState({
   svgCards,
   separateCardsBySuit,
   disableSuitHighlights,
+  suitColorOverrides,
 });
 
 export default settings;

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -369,6 +369,11 @@
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz#8eed982e2ee6f7f4e44c253e12962980791efd46"
   integrity sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
 
+"@icons/material@^0.2.4":
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/@icons/material/-/material-0.2.4.tgz#e90c9f71768b3736e76d7dd6783fc6c2afa88bc8"
+  integrity sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw==
+
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz#fd3db1d59ecf7cf121e80650bb86712f9b55eced"
@@ -4946,7 +4951,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.16, lodash@^4.17.19, lodash@^4.17.5:
+lodash@^4.0.1, lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.16, lodash@^4.17.19, lodash@^4.17.5:
   version "4.17.19"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
@@ -5037,6 +5042,11 @@ map-visit@^1.0.0:
   integrity sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=
   dependencies:
     object-visit "^1.0.0"
+
+material-colors@^1.2.1:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/material-colors/-/material-colors-1.2.6.tgz#6d1958871126992ceecc72f4bcc4d8f010865f46"
+  integrity sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg==
 
 md5.js@^1.3.4:
   version "1.3.5"
@@ -6394,6 +6404,18 @@ randomfill@^1.0.3:
     randombytes "^2.0.5"
     safe-buffer "^5.1.0"
 
+react-color@^2.18.1:
+  version "2.18.1"
+  resolved "https://registry.yarnpkg.com/react-color/-/react-color-2.18.1.tgz#2cda8cc8e06a9e2c52ad391a30ddad31972472f4"
+  integrity sha512-X5XpyJS6ncplZs74ak0JJoqPi+33Nzpv5RYWWxn17bslih+X7OlgmfpmGC1fNvdkK7/SGWYf1JJdn7D2n5gSuQ==
+  dependencies:
+    "@icons/material" "^0.2.4"
+    lodash "^4.17.11"
+    material-colors "^1.2.1"
+    prop-types "^15.5.10"
+    reactcss "^1.2.0"
+    tinycolor2 "^1.4.1"
+
 react-dom@^16.13.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.13.1.tgz#c1bd37331a0486c078ee54c4740720993b2e0e7f"
@@ -6471,6 +6493,13 @@ react@^16.13.1:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
+
+reactcss@^1.2.0:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/reactcss/-/reactcss-1.2.3.tgz#c00013875e557b1cf0dfd9a368a1c3dab3b548dd"
+  integrity sha512-KiwVUcFu1RErkI97ywr8nvx8dNOpT03rbnma0SSalTYjkrPYaEajR4a/MRt6DZ46K6arDRbWMNHF+xH7G7n/8A==
+  dependencies:
+    lodash "^4.0.1"
 
 read-pkg-up@^2.0.0:
   version "2.0.0"
@@ -7522,6 +7551,11 @@ timsort@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/timsort/-/timsort-0.3.0.tgz#405411a8e7e6339fe64db9a234de11dc31e02bd4"
   integrity sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=
+
+tinycolor2@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/tinycolor2/-/tinycolor2-1.4.1.tgz#f4fad333447bc0b07d4dc8e9209d8f39a8ac77e8"
+  integrity sha1-9PrTM0R7wLB9TcjpIJ2POaisd+g=
 
 tmp@^0.0.33:
   version "0.0.33"


### PR DESCRIPTION
Color-blind players may want to customize card colors to make the game
easier for them to play. Allow runtime configuration of colors on a
per-browser basis.

Mostly fixes #218