### PR TITLE
Support end of game kitty reveal

### DIFF
--- a/core/src/game_state.rs
+++ b/core/src/game_state.rs
@@ -249,6 +249,8 @@ pub struct PropagatedState {
     #[serde(default)]
     bid_policy: BidPolicy,
     #[serde(default)]
+    should_reveal_kitty_at_end_of_game: bool,
+    #[serde(default)]
     play_takeback_policy: PlayTakebackPolicy,
     #[serde(default)]
     bid_takeback_policy: BidTakebackPolicy,
@@ -449,6 +451,16 @@ impl PropagatedState {
     pub fn set_bid_policy(&mut self, policy: BidPolicy) -> Result<Vec<MessageVariant>, Error> {
         self.bid_policy = policy;
         Ok(vec![MessageVariant::BidPolicySet { policy }])
+    }
+
+    pub fn set_should_reveal_kitty_at_end_of_game(
+        &mut self,
+        should_reveal: bool,
+    ) -> Result<Vec<MessageVariant>, Error> {
+        self.should_reveal_kitty_at_end_of_game = should_reveal;
+        Ok(vec![MessageVariant::ShouldRevealKittyAtEndOfGameSet {
+            should_reveal,
+        }])
     }
 
     pub fn set_landlord(&mut self, landlord: Option<PlayerID>) -> Result<(), Error> {
@@ -1078,6 +1090,11 @@ impl PlayPhase {
                     points: kitty_points.iter().flat_map(|c| c.points()).sum::<usize>(),
                     multiplier: kitty_multipler,
                 });
+                if self.propagated.should_reveal_kitty_at_end_of_game {
+                    msgs.push(MessageVariant::EndOfGameKittyReveal {
+                        cards: self.kitty.clone(),
+                    });
+                }
             }
         }
         let winner_idx = bail_unwrap!(self.propagated.players.iter().position(|p| p.id == winner));

--- a/core/src/message.rs
+++ b/core/src/message.rs
@@ -36,6 +36,9 @@ pub enum MessageVariant {
         points: usize,
         multiplier: usize,
     },
+    EndOfGameKittyReveal {
+        cards: Vec<Card>,
+    },
     JoinedGame {
         player: PlayerID,
     },
@@ -63,6 +66,9 @@ pub enum MessageVariant {
     },
     BidPolicySet {
         policy: BidPolicy,
+    },
+    ShouldRevealKittyAtEndOfGameSet {
+        should_reveal: bool,
     },
     NumDecksSet {
         num_decks: Option<usize>,

--- a/core/src/trick.rs
+++ b/core/src/trick.rs
@@ -586,6 +586,7 @@ impl Trick {
             self.trump,
             throw_eval_policy,
         );
+
         Ok(msgs)
     }
 

--- a/frontend/src/ChatMessage.tsx
+++ b/frontend/src/ChatMessage.tsx
@@ -32,6 +32,15 @@ const renderMessage = (message: IMessage): JSX.Element => {
           ))}
         </span>
       );
+    case "EndOfGameKittyReveal":
+      return (
+        <span>
+          {variant.cards.map((card, i) => (
+            <InlineCard card={card} key={i} />
+          ))}{" "}
+          in kitty
+        </span>
+      );
     case "GameScoringParametersChanged":
       return renderScoringMessage(message);
     default:

--- a/frontend/src/Credits.tsx
+++ b/frontend/src/Credits.tsx
@@ -41,6 +41,10 @@ const ChangeLog = (): JSX.Element => {
         style={{ content: contentStyle }}
       >
         <h2>Change Log</h2>
+        <p>8/30/2020:</p>
+        <ul>
+          <li>Support end of game kitty reveal.</li>
+        </ul>
         <p>8/09/2020:</p>
         <ul>
           <li>Support configuring different score thresholds for each game.</li>

--- a/frontend/src/Initialize.tsx
+++ b/frontend/src/Initialize.tsx
@@ -215,6 +215,9 @@ const ScoringSettings = (props: IScoringSettings): JSX.Element => {
 interface IUncommonSettings {
   state: IInitializePhase;
   setBidPolicy: (v: React.ChangeEvent<HTMLSelectElement>) => void;
+  setShouldRevealKittyAtEndOfGame: (
+    v: React.ChangeEvent<HTMLSelectElement>
+  ) => void;
   setFirstLandlordSelectionPolicy: (
     v: React.ChangeEvent<HTMLSelectElement>
   ) => void;
@@ -301,6 +304,26 @@ const UncommonSettings = (props: IUncommonSettings): JSX.Element => {
             </option>
             <option value="GreaterLength">
               All bids must have more cards than the previous bids
+            </option>
+          </select>
+        </label>
+      </div>
+      <div>
+        <label>
+          Should Reveal Kitty at End of Game:{" "}
+          <select
+            value={
+              props.state.propagated.should_reveal_kitty_at_end_of_game
+                ? "show"
+                : "hide"
+            }
+            onChange={props.setShouldRevealKittyAtEndOfGame}
+          >
+            <option value="hide">
+              Do not reveal contents of the kitty at the end of the game in chat
+            </option>
+            <option value="show">
+              Reveal contents of the kitty at the end of the game in chat
             </option>
           </select>
         </label>
@@ -435,6 +458,19 @@ const Initialize = (props: IProps): JSX.Element => {
       send({
         Action: {
           SetBidPolicy: evt.target.value,
+        },
+      });
+    }
+  };
+
+  const setShouldRevealKittyAtEndOfGame = (
+    evt: React.ChangeEvent<HTMLSelectElement>
+  ): void => {
+    evt.preventDefault();
+    if (evt.target.value !== "") {
+      send({
+        Action: {
+          SetShouldRevealKittyAtEndOfGame: evt.target.value === "show",
         },
       });
     }
@@ -790,6 +826,13 @@ const Initialize = (props: IProps): JSX.Element => {
               },
             });
             break;
+          case "should_reveal_kitty_at_end_of_game":
+            send({
+              Action: {
+                SetShouldRevealKittyAtEndOfGame: value,
+              },
+            });
+            break;
           case "game_scoring_parameters":
             send({
               Action: {
@@ -1037,6 +1080,7 @@ const Initialize = (props: IProps): JSX.Element => {
         <UncommonSettings
           state={props.state}
           setBidPolicy={setBidPolicy}
+          setShouldRevealKittyAtEndOfGame={setShouldRevealKittyAtEndOfGame}
           setFirstLandlordSelectionPolicy={setFirstLandlordSelectionPolicy}
           setGameStartPolicy={setGameStartPolicy}
           setGameShadowingPolicy={setGameShadowingPolicy}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -33,6 +33,7 @@ export type MessageVariant =
   | { type: "NumDecksSet"; num_decks: number | null }
   | { type: "NumFriendsSet"; num_friends: number | null }
   | { type: "PlayedCards"; cards: string[] }
+  | { type: "EndOfGameKittyReveal"; cards: string[] }
   | { type: "PointsInKitty"; points: number; multiplier: number }
   | { type: "RankAdvanced"; player: number; new_rank: number }
   | { type: "ResettingGame" }
@@ -160,6 +161,7 @@ export interface IPropagatedState {
   game_shadowing_policy: "AllowMultipleSessions" | "SingleSessionOnly";
   game_start_policy: "AllowAnyPlayer" | "AllowLandlordOnly";
   game_scoring_parameters: IGameScoringParameters;
+  should_reveal_kitty_at_end_of_game: boolean;
 }
 
 export interface IGameScoringParameters {


### PR DESCRIPTION
Adds a setting on the initial page that allows users to toggle kitty reveal.

Message displayed when toggled
<img width="346" alt="Screen Shot 2020-08-30 at 8 11 28 PM" src="https://user-images.githubusercontent.com/1388167/91679397-0af9f400-eafd-11ea-9b83-457e28f5e289.png">

Message displayed at end of the game
<img width="308" alt="Screen Shot 2020-08-30 at 8 10 21 PM" src="https://user-images.githubusercontent.com/1388167/91679416-18af7980-eafd-11ea-8ae5-8cd056d9a64a.png">

Settings UI display
<img width="674" alt="Screen Shot 2020-08-30 at 8 11 14 PM" src="https://user-images.githubusercontent.com/1388167/91679423-21a04b00-eafd-11ea-8106-d8b95f787e8c.png">

Great game by the way!