### PR TITLE
Fix memory leak due to zstd compression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -732,12 +732,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 
 [[package]]
-name = "memory_units"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8452105ba047068f40ff7093dd1d9da90898e63dd61736462e9cdda6a90ad3c3"
-
-[[package]]
 name = "mime"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1392,7 +1386,6 @@ dependencies = [
  "smallvec",
  "wasm-bindgen",
  "web-sys",
- "wee_alloc",
 ]
 
 [[package]]
@@ -1893,18 +1886,6 @@ checksum = "8bc359e5dd3b46cb9687a051d50a2fdd228e4ba7cf6fcf861a5365c3d671a642"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "wee_alloc"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb3b5a6b2bb17cb6ad44a2e68a43e8d2722c997da10e928665c72ec6c0a0b8e"
-dependencies = [
- "cfg-if",
- "libc",
- "memory_units",
- "winapi 0.3.8",
 ]
 
 [[package]]

--- a/frontend/shengji-wasm/Cargo.toml
+++ b/frontend/shengji-wasm/Cargo.toml
@@ -24,4 +24,3 @@ shengji-types = { path = "../../backend/backend-types" }
 smallvec = { version = "1.3.0", features = ["serde"] }
 wasm-bindgen = { version = "0.2.45", features = ["serde-serialize"] }
 web-sys = { version = "0.3.22", features = ["console"]}
-wee_alloc = { version = "0.4.2"}

--- a/frontend/shengji-wasm/src/lib.rs
+++ b/frontend/shengji-wasm/src/lib.rs
@@ -17,9 +17,6 @@ use smallvec::SmallVec;
 use wasm_bindgen::prelude::*;
 // use web_sys::console;
 
-#[global_allocator]
-static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
-
 lazy_static::lazy_static! {
     static ref ZSTD_DICT: Vec<u8> = {
         let mut reader = Cursor::new(ZSTD_ZSTD_DICT);

--- a/frontend/src/Credits.tsx
+++ b/frontend/src/Credits.tsx
@@ -9,7 +9,7 @@ const contentStyle = {
   transform: "translate(-50%, -50%)",
 };
 
-const changeLogVersion: number = 1;
+const changeLogVersion: number = 2;
 
 const ChangeLog = (): JSX.Element => {
   const [modalOpen, setModalOpen] = React.useState<boolean>(false);
@@ -41,6 +41,10 @@ const ChangeLog = (): JSX.Element => {
         style={{ content: contentStyle }}
       >
         <h2>Change Log</h2>
+        <p>9/18/2020:</p>
+        <ul>
+          <li>Fix performance issues in long games.</li>
+        </ul>
         <p>8/30/2020:</p>
         <ul>
           <li>Support end of game kitty reveal.</li>


### PR DESCRIPTION
1. re-use filereader on safari, otherwise filereader leaks memory
2. use the default allocator rather than wee_alloc, since wee_alloc doesn't
   return any memory to the browser ever.

Fixes #233