### PR TITLE
Add setting to hide player who beat throw & setting to remove format-following constraint

### DIFF
--- a/core/src/game_state.rs
+++ b/core/src/game_state.rs
@@ -15,7 +15,7 @@ use crate::settings::{
     FriendSelectionPolicy, GameMode, GameModeSettings, GameStartPolicy, KittyBidPolicy,
     KittyPenalty, KittyTheftPolicy, PlayTakebackPolicy, PropagatedState, ThrowPenalty,
 };
-use crate::trick::{Trick, TrickEnded, TrickUnit};
+use crate::trick::{PlayCards, Trick, TrickEnded, TrickUnit};
 use crate::types::{Card, Number, PlayerID, Trump, FULL_DECK};
 
 macro_rules! bail_unwrap {
@@ -300,14 +300,15 @@ impl PlayPhase {
         cards: &[Card],
         format_hint: Option<&'_ [TrickUnit]>,
     ) -> Result<Vec<MessageVariant>, Error> {
-        let mut msgs = self.trick.play_cards(
+        let mut msgs = self.trick.play_cards(PlayCards {
             id,
-            &mut self.hands,
+            hands: &mut self.hands,
             cards,
-            self.propagated.trick_draw_policy,
-            self.propagated.throw_evaluation_policy,
+            trick_draw_policy: self.propagated.trick_draw_policy,
+            throw_eval_policy: self.propagated.throw_evaluation_policy,
             format_hint,
-        )?;
+            hide_throw_halting_player: self.propagated.hide_throw_halting_player,
+        })?;
         if self.propagated.hide_played_cards {
             for msg in &mut msgs {
                 match msg {

--- a/core/src/interactive.rs
+++ b/core/src/interactive.rs
@@ -487,9 +487,9 @@ impl BroadcastMessage {
             ThrowPenaltySet { throw_penalty: ThrowPenalty::TenPointsPerAttempt } => format!("{} set the throw penalty to 10 points per throw", n?),
             KittyBidPolicySet { policy: KittyBidPolicy::FirstCard } => format!("{} set the bid-from-bottom policy to be the first card revealed", n?),
             KittyBidPolicySet { policy: KittyBidPolicy::FirstCardOfLevelOrHighest } => format!("{} set the bid-from-bottom policy to be the first card of the appropriate level, or the highest if none are found", n?),
-            TrickDrawPolicySet { policy: TrickDrawPolicy::NoProtections } => format!("{} removed long-tuple protections (pair can draw triple)", n?),
-            TrickDrawPolicySet { policy: TrickDrawPolicy::LongerTuplesProtected } => format!("{}
-                protected longer tuples from being drawn out by shorter ones (pair does not draw triple)", n?),
+            TrickDrawPolicySet { policy: TrickDrawPolicy::NoProtections } => format!("{} removed all protections (pair can draw triple)", n?),
+            TrickDrawPolicySet { policy: TrickDrawPolicy::NoFormatBasedDraw } => format!("{} removed format-based forced-plays (pairs do not draw pairs)", n?),
+            TrickDrawPolicySet { policy: TrickDrawPolicy::LongerTuplesProtected } => format!("{} protected longer tuples from being drawn out by shorter ones (pair does not draw triple)", n?),
             ThrowEvaluationPolicySet { policy: ThrowEvaluationPolicy::All } => format!("{} set throws to be evaluated based on all of the cards", n?),
             ThrowEvaluationPolicySet { policy: ThrowEvaluationPolicy::Highest } => format!("{} set throws to be evaluated based on the highest card", n?),
             ThrowEvaluationPolicySet { policy: ThrowEvaluationPolicy::TrickUnitLength } => format!("{} set throws to be evaluated based on the longest component", n?),

--- a/core/src/message.rs
+++ b/core/src/message.rs
@@ -93,7 +93,7 @@ pub enum MessageVariant {
     },
     ThrowFailed {
         original_cards: Vec<Card>,
-        better_player: PlayerID,
+        better_player: Option<PlayerID>,
     },
     SetDefendingPointVisibility {
         visible: bool,
@@ -155,5 +155,8 @@ pub enum MessageVariant {
     EndOfGameSummary {
         landlord_won: bool,
         non_landlords_points: isize,
+    },
+    HideThrowHaltingPlayer {
+        set: bool,
     },
 }

--- a/core/src/settings.rs
+++ b/core/src/settings.rs
@@ -289,6 +289,8 @@ pub struct PropagatedState {
     pub(crate) game_start_policy: GameStartPolicy,
     #[serde(default)]
     pub(crate) game_scoring_parameters: GameScoringParameters,
+    #[serde(default)]
+    pub(crate) hide_throw_halting_player: bool,
 }
 
 impl PropagatedState {
@@ -704,6 +706,20 @@ impl PropagatedState {
         if policy != self.game_start_policy {
             self.game_start_policy = policy;
             Ok(vec![MessageVariant::GameStartPolicySet { policy }])
+        } else {
+            Ok(vec![])
+        }
+    }
+
+    pub fn set_hide_throw_halting_player(
+        &mut self,
+        hide_throw_halting_player: bool,
+    ) -> Result<Vec<MessageVariant>, Error> {
+        if self.hide_throw_halting_player != hide_throw_halting_player {
+            self.hide_throw_halting_player = hide_throw_halting_player;
+            Ok(vec![MessageVariant::HideThrowHaltingPlayer {
+                set: hide_throw_halting_player,
+            }])
         } else {
             Ok(vec![])
         }

--- a/frontend/src/Credits.tsx
+++ b/frontend/src/Credits.tsx
@@ -9,7 +9,7 @@ const contentStyle: React.CSSProperties = {
   transform: "translate(-50%, -50%)",
 };
 
-const changeLogVersion: number = 7;
+const changeLogVersion: number = 8;
 
 const ChangeLog = (): JSX.Element => {
   const [modalOpen, setModalOpen] = React.useState<boolean>(false);
@@ -41,27 +41,40 @@ const ChangeLog = (): JSX.Element => {
         style={{ content: contentStyle }}
       >
         <h2>Change Log</h2>
+        <p>12/07/2020:</p>
+        <ul>
+          <li>
+            Add a setting which hides the indication of which player that can
+            defeat a throw.
+          </li>
+        </ul>
         <p>11/22/2020:</p>
         <ul>
-          More rigorously define trick-format decomposition, especially when
-          more than four decks are involved. See the issues referenced in{" "}
-          <a
-            href="https://github.com/rbtying/shengji/pull/258/files"
-            target="_blank"
-            rel="noreferrer"
-          >
-            PR #258
-          </a>{" "}
-          for details.
+          <li>
+            More rigorously define trick-format decomposition, especially when
+            more than four decks are involved. See the issues referenced in{" "}
+            <a
+              href="https://github.com/rbtying/shengji/pull/258/files"
+              target="_blank"
+              rel="noreferrer"
+            >
+              PR #258
+            </a>{" "}
+            for details.
+          </li>
         </ul>
         <p>11/13/2020:</p>
         <ul>
-          Fix bug in longest-component throw-evaluation policy where the winner
-          for tricks of single cards was always the first player.
+          <li>
+            Fix bug in longest-component throw-evaluation policy where the
+            winner for tricks of single cards was always the first player.
+          </li>
         </ul>
         <p>11/11/2020:</p>
         <ul>
-          Support a throw evaluation policy based on the longest component.
+          <li>
+            Support a throw evaluation policy based on the longest component.
+          </li>
         </ul>
         <p>11/01/2020:</p>
         <ul>

--- a/frontend/src/Credits.tsx
+++ b/frontend/src/Credits.tsx
@@ -47,6 +47,10 @@ const ChangeLog = (): JSX.Element => {
             Add a setting which hides the indication of which player that can
             defeat a throw.
           </li>
+          <li>
+            Add a card-protection setting which disables format-based play
+            requirements.
+          </li>
         </ul>
         <p>11/22/2020:</p>
         <ul>

--- a/frontend/src/Initialize.tsx
+++ b/frontend/src/Initialize.tsx
@@ -225,6 +225,7 @@ interface IUncommonSettings {
   setGameStartPolicy: (v: React.ChangeEvent<HTMLSelectElement>) => void;
   setGameShadowingPolicy: (v: React.ChangeEvent<HTMLSelectElement>) => void;
   setKittyBidPolicy: (v: React.ChangeEvent<HTMLSelectElement>) => void;
+  setHideThrowHaltingPlayer: (v: React.ChangeEvent<HTMLSelectElement>) => void;
 }
 
 const UncommonSettings = (props: IUncommonSettings): JSX.Element => {
@@ -344,6 +345,24 @@ const UncommonSettings = (props: IUncommonSettings): JSX.Element => {
             </option>
             <option value="show">
               Reveal contents of the kitty at the end of the game in chat
+            </option>
+          </select>
+        </label>
+      </div>
+      <div>
+        <label>
+          Show player which defeats throw:{" "}
+          <select
+            value={
+              props.state.propagated.hide_throw_halting_player ? "hide" : "show"
+            }
+            onChange={props.setHideThrowHaltingPlayer}
+          >
+            <option value="hide">
+              Hide the player who defeats a potential throw
+            </option>
+            <option value="show">
+              Show the player who defeats a potential throw
             </option>
           </select>
         </label>
@@ -503,6 +522,18 @@ const Initialize = (props: IProps): JSX.Element => {
       send({
         Action: {
           SetShouldRevealKittyAtEndOfGame: evt.target.value === "show",
+        },
+      });
+    }
+  };
+  const setHideThrowHaltingPlayer = (
+    evt: React.ChangeEvent<HTMLSelectElement>
+  ): void => {
+    evt.preventDefault();
+    if (evt.target.value !== "") {
+      send({
+        Action: {
+          SetHideThrowHaltingPlayer: evt.target.value === "hide",
         },
       });
     }
@@ -872,6 +903,9 @@ const Initialize = (props: IProps): JSX.Element => {
               },
             });
             break;
+          case "hide_throw_halting_player":
+            send({ Action: { SetHideThrowHaltingPlayer: value } });
+            break;
           case "game_scoring_parameters":
             send({
               Action: {
@@ -1124,6 +1158,7 @@ const Initialize = (props: IProps): JSX.Element => {
           setBidPolicy={setBidPolicy}
           setJokerBidPolicy={setJokerBidPolicy}
           setShouldRevealKittyAtEndOfGame={setShouldRevealKittyAtEndOfGame}
+          setHideThrowHaltingPlayer={setHideThrowHaltingPlayer}
           setFirstLandlordSelectionPolicy={setFirstLandlordSelectionPolicy}
           setGameStartPolicy={setGameStartPolicy}
           setGameShadowingPolicy={setGameShadowingPolicy}

--- a/frontend/src/Initialize.tsx
+++ b/frontend/src/Initialize.tsx
@@ -1130,6 +1130,9 @@ const Initialize = (props: IProps): JSX.Element => {
               <option value="LongerTuplesProtected">
                 Longer tuple (triple) is protected from shorter (pair)
               </option>
+              <option value="NoFormatBasedDraw">
+                No format-based requirements (pairs do not draw pairs)
+              </option>
             </select>
           </label>
         </div>

--- a/frontend/src/Play.tsx
+++ b/frontend/src/Play.tsx
@@ -288,7 +288,7 @@ const TrickFormatHelper = (props: {
           </p>
         )}
 
-        {decomp.length > 1 && (
+        {decomp.length > 1 && props.trickDrawPolicy !== "NoFormatBasedDraw" && (
           <>
             <p>
               If you can&apos;t play that, but you <em>can</em> play one of the

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -170,6 +170,7 @@ export interface IPropagatedState {
   game_start_policy: "AllowAnyPlayer" | "AllowLandlordOnly";
   game_scoring_parameters: IGameScoringParameters;
   should_reveal_kitty_at_end_of_game: boolean;
+  hide_throw_halting_player: boolean;
 }
 
 export interface IGameScoringParameters {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -139,7 +139,10 @@ export type JokerBidPolicy =
   | "BothTwoOrMore"
   | "BothNumDecks"
   | "LJNumDecksHJNumDecksLessOne";
-export type TrickDrawPolicy = "NoProtections" | "LongerTuplesProtected";
+export type TrickDrawPolicy =
+  | "NoProtections"
+  | "LongerTuplesProtected"
+  | "NoFormatBasedDraw";
 
 export interface IPropagatedState {
   game_mode: IGameModeSettings;


### PR DESCRIPTION
Add two requested features:
- setting to hide the player who beat the throw (fixes #266)
- setting to remove format-following constraint on plays (fixes #265)