### PR TITLE
Support a friend selection policy that disallows point cards

### DIFF
--- a/core/src/game_state.rs
+++ b/core/src/game_state.rs
@@ -762,8 +762,8 @@ impl ExchangePhase {
                     match friend.card.points() {
                         Some(points) if points > 0 => {
                             bail!("you can't pick a point card as your friend")
-                        },
-                        _ => ()
+                        }
+                        _ => (),
                     }
                 }
 

--- a/core/src/game_state.rs
+++ b/core/src/game_state.rs
@@ -1307,8 +1307,8 @@ mod tests {
         KittyTheftPolicy, MessageVariant, PlayPhase, Player,
     };
 
-    use crate::types::{cards, Card, Number, PlayerID};
     use crate::settings::FriendSelectionPolicy;
+    use crate::types::{cards, Card, Number, PlayerID};
 
     #[test]
     fn test_player_level_deltas() {
@@ -1517,7 +1517,7 @@ mod tests {
         play.play_cards(p3, &[S_3, S_5, S_10, S_J, S_Q]).unwrap();
         play.play_cards(p4, &[S_6, S_6, S_6, C_8, C_9]).unwrap();
     }
-    
+
     #[test]
     fn test_set_friends() {
         use cards::*;
@@ -1540,16 +1540,14 @@ mod tests {
         draw.draw_card(p3).unwrap();
         draw.draw_card(p4).unwrap();
         draw.draw_card(p1).unwrap();
-        
+
         assert!(draw.bid(p1, S_7, 2));
-        
+
         let mut exchange = draw.advance(p2).unwrap();
-        let friends = vec![
-            FriendSelection {
-                card: C_K,
-                initial_skip: 0,
-            },
-        ];
+        let friends = vec![FriendSelection {
+            card: C_K,
+            initial_skip: 0,
+        }];
         exchange.set_friends(p2, friends).unwrap_err();
     }
 

--- a/core/src/game_state.rs
+++ b/core/src/game_state.rs
@@ -1522,33 +1522,68 @@ mod tests {
     fn test_set_friends() {
         use cards::*;
 
-        let mut init = InitializePhase::new();
-        init.set_game_mode(GameModeSettings::FindingFriends { num_friends: None })
-            .unwrap();
-        init.set_friend_selection_policy(FriendSelectionPolicy::PointCardNotAllowed)
-            .unwrap();
-        let p1 = init.add_player("p1".into()).unwrap().0;
-        let p2 = init.add_player("p2".into()).unwrap().0;
-        let p3 = init.add_player("p3".into()).unwrap().0;
-        let p4 = init.add_player("p4".into()).unwrap().0;
-        init.set_landlord(Some(p2)).unwrap();
-        init.set_rank(p2, Number::Seven).unwrap();
+        let setup_exchange = |friend_selection_policy| {
+            let mut init = InitializePhase::new();
+            init.set_game_mode(GameModeSettings::FindingFriends { num_friends: None })
+                .unwrap();
+            init.set_friend_selection_policy(friend_selection_policy)
+                .unwrap();
+            let p1 = init.add_player("p1".into()).unwrap().0;
+            let p2 = init.add_player("p2".into()).unwrap().0;
+            let p3 = init.add_player("p3".into()).unwrap().0;
+            let p4 = init.add_player("p4".into()).unwrap().0;
+            init.set_landlord(Some(p2)).unwrap();
+            init.set_rank(p2, Number::Seven).unwrap();
 
-        let mut draw = init.start(PlayerID(1)).unwrap();
-        draw.deck = vec![S_7, S_7, S_7, S_7];
-        draw.draw_card(p2).unwrap();
-        draw.draw_card(p3).unwrap();
-        draw.draw_card(p4).unwrap();
-        draw.draw_card(p1).unwrap();
+            let mut draw = init.start(PlayerID(1)).unwrap();
+            draw.deck = vec![S_7, S_7, S_7, S_7];
+            draw.draw_card(p2).unwrap();
+            draw.draw_card(p3).unwrap();
+            draw.draw_card(p4).unwrap();
+            draw.draw_card(p1).unwrap();
 
-        assert!(draw.bid(p1, S_7, 2));
+            assert!(draw.bid(p1, S_7, 1));
 
-        let mut exchange = draw.advance(p2).unwrap();
-        let friends = vec![FriendSelection {
-            card: C_K,
-            initial_skip: 0,
-        }];
-        exchange.set_friends(p2, friends).unwrap_err();
+            (p2, draw.advance(p2).unwrap())
+        };
+
+        let test_cases = vec![
+            (
+                FriendSelectionPolicy::Unrestricted,
+                vec![(C_K, true), (S_3, false), (C_3, true), (C_A, true)],
+            ),
+            (
+                FriendSelectionPolicy::PointCardNotAllowed,
+                vec![(C_K, false), (S_3, false), (C_3, true), (C_A, true)],
+            ),
+            (
+                FriendSelectionPolicy::HighestCardNotAllowed,
+                vec![(C_K, true), (S_3, false), (C_3, true), (C_A, false)],
+            ),
+        ];
+
+        for (friend_selection_policy, friends) in test_cases {
+            for (friend, ok) in friends {
+                let (p2, mut exchange) = setup_exchange(friend_selection_policy);
+
+                assert_eq!(
+                    exchange
+                        .set_friends(
+                            p2,
+                            vec![FriendSelection {
+                                card: friend,
+                                initial_skip: 0,
+                            }],
+                        )
+                        .is_ok(),
+                    ok,
+                    "Expected {:?} to be a {} friend for {:?}",
+                    friend,
+                    if ok { "legal" } else { "illegal" },
+                    friend_selection_policy
+                );
+            }
+        }
     }
 
     #[test]

--- a/core/src/game_state.rs
+++ b/core/src/game_state.rs
@@ -755,6 +755,18 @@ impl ExchangePhase {
                         _ => (),
                     }
                 }
+
+                if let FriendSelectionPolicy::PointCardNotAllowed =
+                    self.propagated.friend_selection_policy
+                {
+                    match friend.card.points() {
+                        Some(points) if points > 0 => {
+                            bail!("you can't pick a point card as your friend")
+                        },
+                        _ => ()
+                    }
+                }
+
                 friends.push(Friend {
                     card: friend.card,
                     initial_skip: friend.initial_skip,

--- a/core/src/interactive.rs
+++ b/core/src/interactive.rs
@@ -450,6 +450,7 @@ impl BroadcastMessage {
             KittySizeSet { size: None } => format!("{} set the number of cards in the bottom to default", n?),
             FriendSelectionPolicySet { policy: FriendSelectionPolicy::Unrestricted} => format!("{} allowed any non-trump card to be selected as a friend", n?),
             FriendSelectionPolicySet { policy: FriendSelectionPolicy::HighestCardNotAllowed} => format!("{} disallowed the highest non-trump card, as well as trump cards, from being selected as a friend", n?),
+            FriendSelectionPolicySet { policy: FriendSelectionPolicy::PointCardNotAllowed} => format!("{} disallowed point cards, as well as trump cards, from being selected as a friend", n?),
             FirstLandlordSelectionPolicySet { policy: FirstLandlordSelectionPolicy::ByWinningBid} => format!("{} set winning bid to decide both landlord and trump", n?),
             FirstLandlordSelectionPolicySet { policy: FirstLandlordSelectionPolicy::ByFirstBid} => format!("{} set first bid to decide landlord, winning bid to decide trump", n?),
             BidPolicySet { policy: BidPolicy::JokerOrGreaterLength} => format!("{} allowed joker bids to outbid non-joker bids with the same number of cards", n?),

--- a/core/src/settings.rs
+++ b/core/src/settings.rs
@@ -137,6 +137,7 @@ impl_slog_value!(AdvancementPolicy);
 pub enum FriendSelectionPolicy {
     Unrestricted,
     HighestCardNotAllowed,
+    PointCardNotAllowed,
 }
 
 impl Default for FriendSelectionPolicy {

--- a/frontend/src/Credits.tsx
+++ b/frontend/src/Credits.tsx
@@ -41,6 +41,12 @@ const ChangeLog = (): JSX.Element => {
         style={{ content: contentStyle }}
       >
         <h2>Change Log</h2>
+        <p>12/11/2020:</p>
+        <ul>
+          <li>
+            Support a friend selection policy that disallows point cards.
+          </li>
+        </ul>
         <p>12/07/2020:</p>
         <ul>
           <li>

--- a/frontend/src/Credits.tsx
+++ b/frontend/src/Credits.tsx
@@ -43,9 +43,7 @@ const ChangeLog = (): JSX.Element => {
         <h2>Change Log</h2>
         <p>12/11/2020:</p>
         <ul>
-          <li>
-            Support a friend selection policy that disallows point cards.
-          </li>
+          <li>Support a friend selection policy that disallows point cards.</li>
         </ul>
         <p>12/07/2020:</p>
         <ul>

--- a/frontend/src/FriendSelect.tsx
+++ b/frontend/src/FriendSelect.tsx
@@ -53,7 +53,7 @@ const FriendSelect = (props: IProps): JSX.Element => {
     currentValue.value = c.value;
   }
 
-  const notTrumpFilter = (c: ICardInfo) => {
+  const notTrumpFilter: (c: ICardInfo) => boolean = (c: ICardInfo) => {
     return (
       c.number !== null &&
       c.number !== rank &&
@@ -69,8 +69,8 @@ const FriendSelect = (props: IProps): JSX.Element => {
     },
     Unrestricted: (_c: ICardInfo) => true,
   };
-  const policyFilter =
-    policyFilters[props.friend_selection_policy] || ((_c: ICardInfo) => true);
+  const policyFilter: (c: ICardInfo) => boolean =
+    policyFilters[props.friend_selection_policy];
 
   preloadedCards
     .filter((c: ICardInfo) => notTrumpFilter(c) && policyFilter(c))

--- a/frontend/src/FriendSelect.tsx
+++ b/frontend/src/FriendSelect.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import Select from "react-select";
-import { ITrump } from "./types";
+import { ICardInfo, ITrump } from "./types";
 import ArrayUtils from "./util/array";
 import preloadedCards from "./preloadedCards";
 import InlineCard from "./InlineCard";
@@ -53,26 +53,33 @@ const FriendSelect = (props: IProps): JSX.Element => {
     currentValue.value = c.value;
   }
 
-  preloadedCards.forEach((c) => {
-    if (
+  const notTrumpFilter = (c: ICardInfo) => {
+    return (
       c.number !== null &&
       c.number !== rank &&
       (props.trump.Standard == null || c.typ !== props.trump.Standard.suit)
-    ) {
-      // exclude highest card
-      if (
-        (props.friend_selection_policy === "HighestCardNotAllowed" &&
-          ((rank !== "A" && c.number !== "A") ||
-            (rank === "A" && c.number !== "K"))) ||
-        props.friend_selection_policy === "Unrestricted"
-      ) {
-        cardOptions.push({
-          label: `${c.number}${c.typ}`,
-          value: c.value,
-        });
-      }
-    }
-  });
+    );
+  };
+  const policyFilters: { [s: string]: (c: ICardInfo) => boolean } = {
+    PointCardNotAllowed: (c: ICardInfo) => c.points === 0,
+    HighestCardNotAllowed: (c: ICardInfo) => {
+      return (
+        (rank !== "A" && c.number !== "A") || (rank === "A" && c.number !== "K")
+      );
+    },
+    Unrestricted: (_c: ICardInfo) => true,
+  };
+  const policyFilter =
+    policyFilters[props.friend_selection_policy] || ((_c: ICardInfo) => true);
+
+  preloadedCards
+    .filter((c: ICardInfo) => notTrumpFilter(c) && policyFilter(c))
+    .forEach((c: ICardInfo) =>
+      cardOptions.push({
+        label: `${c.number}${c.typ}`,
+        value: c.value,
+      })
+    );
 
   return (
     <div className="friend-select">

--- a/frontend/src/Initialize.tsx
+++ b/frontend/src/Initialize.tsx
@@ -51,7 +51,7 @@ const DifficultySettings = (props: IDifficultyProps): JSX.Element => {
               Non-trump cards, except the highest
             </option>
             <option value="PointCardNotAllowed">
-              Non-point cards, except the highest
+              Non-trump, non-point cards
             </option>
           </select>
         </label>

--- a/frontend/src/Initialize.tsx
+++ b/frontend/src/Initialize.tsx
@@ -50,6 +50,9 @@ const DifficultySettings = (props: IDifficultyProps): JSX.Element => {
             <option value="HighestCardNotAllowed">
               Non-trump cards, except the highest
             </option>
+            <option value="PointCardNotAllowed">
+              Non-point cards, except the highest
+            </option>
           </select>
         </label>
       </div>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -148,7 +148,10 @@ export interface IPropagatedState {
   game_mode: IGameModeSettings;
   hide_landlord_points: boolean | null;
   kitty_size: number | null;
-  friend_selection_policy: "Unrestricted" | "HighestCardNotAllowed";
+  friend_selection_policy:
+    | "Unrestricted"
+    | "HighestCardNotAllowed"
+    | "PointCardNotAllowed";
   first_landlord_selection_policy: "ByWinningBid" | "ByFirstBid";
   bid_policy: BidPolicy;
   joker_bid_policy: JokerBidPolicy;


### PR DESCRIPTION
The group I play with plays with this rule, and I often forget about it when selecting friends.

By the way, thanks for building/maintaining this game!

![Screen Shot 2020-12-11 at 9 13 41 PM](https://user-images.githubusercontent.com/6193072/101970131-9d2e8f80-3bf6-11eb-8b7f-bed90e9b3822.png)
![Screen Shot 2020-12-11 at 9 13 14 PM](https://user-images.githubusercontent.com/6193072/101970132-9dc72600-3bf6-11eb-9547-19d4cf18d03d.png)
![Screen Shot 2020-12-11 at 9 15 07 PM](https://user-images.githubusercontent.com/6193072/101970130-9d2e8f80-3bf6-11eb-8f7a-d3efa07cc563.png)

