### PR TITLE
Update PointCardNotAllowed policy

### DIFF
--- a/frontend/src/Credits.tsx
+++ b/frontend/src/Credits.tsx
@@ -41,6 +41,13 @@ const ChangeLog = (): JSX.Element => {
         style={{ content: contentStyle }}
       >
         <h2>Change Log</h2>
+        <p>1/18/2021:</p>
+        <ul>
+          <li>
+            Ammend the "PointCardNotAllowed" friend selection policy. King is
+            now a valid friend when the landlord's rank is Ace.
+          </li>
+        </ul>
         <p>1/8/2021:</p>
         <ul>
           <li>

--- a/frontend/src/Credits.tsx
+++ b/frontend/src/Credits.tsx
@@ -44,8 +44,8 @@ const ChangeLog = (): JSX.Element => {
         <p>1/18/2021:</p>
         <ul>
           <li>
-            Ammend the "PointCardNotAllowed" friend selection policy. King is
-            now a valid friend when the landlord's rank is Ace.
+            Ammend the &ldquo;PointCardNotAllowed&rdquo; friend selection policy.
+            King is now a valid friend when the landlord&apos;s rank is Ace.
           </li>
         </ul>
         <p>1/8/2021:</p>

--- a/frontend/src/Credits.tsx
+++ b/frontend/src/Credits.tsx
@@ -44,8 +44,9 @@ const ChangeLog = (): JSX.Element => {
         <p>1/18/2021:</p>
         <ul>
           <li>
-            Ammend the &ldquo;PointCardNotAllowed&rdquo; friend selection policy.
-            King is now a valid friend when the landlord&apos;s rank is Ace.
+            Ammend the &ldquo;PointCardNotAllowed&rdquo; friend selection
+            policy. King is now a valid friend when the landlord&apos;s rank is
+            Ace.
           </li>
         </ul>
         <p>1/8/2021:</p>

--- a/frontend/src/FriendSelect.tsx
+++ b/frontend/src/FriendSelect.tsx
@@ -61,7 +61,9 @@ const FriendSelect = (props: IProps): JSX.Element => {
     );
   };
   const policyFilters: { [s: string]: (c: ICardInfo) => boolean } = {
-    PointCardNotAllowed: (c: ICardInfo) => c.points === 0,
+    PointCardNotAllowed: (c: ICardInfo) => {
+      return c.points === 0 || (rank === "A" && c.number === "K");
+    },
     HighestCardNotAllowed: (c: ICardInfo) => {
       return (
         (rank !== "A" && c.number !== "A") || (rank === "A" && c.number !== "K")

--- a/frontend/src/Initialize.tsx
+++ b/frontend/src/Initialize.tsx
@@ -51,7 +51,7 @@ const DifficultySettings = (props: IDifficultyProps): JSX.Element => {
               Non-trump cards, except the highest
             </option>
             <option value="PointCardNotAllowed">
-              Non-trump, non-point cards
+              Non-trump, non-point cards, unless the highest
             </option>
           </select>
         </label>

--- a/frontend/src/Initialize.tsx
+++ b/frontend/src/Initialize.tsx
@@ -51,7 +51,7 @@ const DifficultySettings = (props: IDifficultyProps): JSX.Element => {
               Non-trump cards, except the highest
             </option>
             <option value="PointCardNotAllowed">
-              Non-trump, non-point cards, unless the highest
+              Non-trump, non-point cards (except K when playing A)
             </option>
           </select>
         </label>


### PR DESCRIPTION
I missed a subtle detail when implementing the `PointCardNotAllowed` policy in #269: `king` is supposed to be a valid friend selection when the landlord's rank is `ace`.

I assumed this an uncommonly rule, so I decided to amend the current rule instead of adding a new one. I'd be happy to make a separate one if people actually use the current version.