### PR TITLE
Add point progress bar visualization

### DIFF
--- a/frontend/src/Credits.tsx
+++ b/frontend/src/Credits.tsx
@@ -41,6 +41,12 @@ const ChangeLog = (): JSX.Element => {
         style={{ content: contentStyle }}
       >
         <h2>Change Log</h2>
+        <p>1/21/2021:</p>
+        <ul>
+          <li>
+            Add a scoring progress bar with point thresholds.
+          </li>
+        </ul>
         <p>1/8/2021:</p>
         <ul>
           <li>

--- a/frontend/src/Credits.tsx
+++ b/frontend/src/Credits.tsx
@@ -43,9 +43,7 @@ const ChangeLog = (): JSX.Element => {
         <h2>Change Log</h2>
         <p>1/21/2021:</p>
         <ul>
-          <li>
-            Add a scoring progress bar with point thresholds.
-          </li>
+          <li>Add a scoring progress bar with point thresholds.</li>
         </ul>
         <p>1/18/2021:</p>
         <ul>

--- a/frontend/src/Points.tsx
+++ b/frontend/src/Points.tsx
@@ -24,7 +24,7 @@ const Points = (props: IProps): JSX.Element => {
   const pointsPerPlayer = ObjectUtils.mapValues(props.points, (cards) =>
     ArrayUtils.sum(cards.map((card) => cardLookup[card].points))
   );
-  const { computeScore } = React.useContext(WasmContext);
+  const { computeScore, explainScoring } = React.useContext(WasmContext);
   const totalPointsPlayed = ArrayUtils.sum(Object.values(pointsPerPlayer));
   const nonLandlordPoints = ArrayUtils.sum(
     props.players
@@ -94,13 +94,25 @@ const Points = (props: IProps): JSX.Element => {
 
   thresholdStr += ` (next threshold: ${nextThreshold}分)`;
 
+  const { results: scoreTransitions } = explainScoring({
+    params: props.gameScoringParameters,
+    smaller_landlord_team_size: false,
+    num_decks: props.numDecks,
+  });
+
   return (
     <div className="points">
       <h2>Points</h2>
       <ProgressBar
+        checkpoints={scoreTransitions
+          .map((transition) => transition.point_threshold)
+          .filter(
+            (threshold) => threshold >= 10 && threshold < props.numDecks * 100
+          )}
         numDecks={props.numDecks}
         landlordPoints={totalPointsPlayed - nonLandlordPoints}
         challengerPoints={nonLandlordPoints}
+        hideLandlordPoints={props.hideLandlordPoints}
       />
       <p>
         {penaltyDelta === 0

--- a/frontend/src/Points.tsx
+++ b/frontend/src/Points.tsx
@@ -96,7 +96,7 @@ const Points = (props: IProps): JSX.Element => {
 
   const { results: scoreTransitions } = explainScoring({
     params: props.gameScoringParameters,
-    smaller_landlord_team_size: false,
+    smaller_landlord_team_size: props.smallerTeamSize,
     num_decks: props.numDecks,
   });
 

--- a/frontend/src/Points.tsx
+++ b/frontend/src/Points.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import ProgressBar from "./ProgressBar";
 import { IPlayer, IGameScoringParameters } from "./types";
 import ArrayUtils from "./util/array";
 import ObjectUtils from "./util/object";
@@ -96,6 +97,11 @@ const Points = (props: IProps): JSX.Element => {
   return (
     <div className="points">
       <h2>Points</h2>
+      <ProgressBar
+        numDecks={props.numDecks}
+        landlordPoints={totalPointsPlayed - nonLandlordPoints}
+        challengerPoints={nonLandlordPoints}
+      />
       <p>
         {penaltyDelta === 0
           ? nonLandlordPoints

--- a/frontend/src/ProgressBar.tsx
+++ b/frontend/src/ProgressBar.tsx
@@ -1,9 +1,11 @@
 import * as React from "react";
 
 interface IProps {
+  checkpoints: number[];
   numDecks: number;
   challengerPoints: number;
   landlordPoints: number;
+  hideLandlordPoints: boolean;
 }
 
 interface CheckpointCircleProps {
@@ -16,16 +18,28 @@ interface CheckpointCircleProps {
 const CheckpointCircle = (props: CheckpointCircleProps): JSX.Element => {
   return (
     <div
-      className="checkpoint-circle"
       style={{
         position: "relative",
         left: props.position,
         transform: "translate(-50%, 0%)",
         backgroundColor: props.color,
         marginTop: props.marginTop,
+        height: "40px",
+        width: "40px",
+        borderRadius: "25px",
       }}
     >
-      <div className="checkpoint-circle-content">{props.text}</div>
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          justifyContent: "center",
+          alignItems: "center",
+        }}
+      >
+        {props.text}
+      </div>
     </div>
   );
 };
@@ -41,10 +55,7 @@ const ProgressBar = (props: IProps): JSX.Element => {
 
   const { numDecks, challengerPoints, landlordPoints } = props;
   const totalPoints = numDecks * 100;
-  const checkpoints = [0.2, 0.4, 0.6, 0.8].map(
-    (proportion) => proportion * totalPoints
-  );
-  const checkpointColors = checkpoints.map((checkpoint) => {
+  const checkpointColors = props.checkpoints.map((checkpoint) => {
     if (landlordPoints >= checkpoint) {
       return landlordColor;
     } else if (challengerPoints >= totalPoints - checkpoint) {
@@ -53,53 +64,57 @@ const ProgressBar = (props: IProps): JSX.Element => {
       return neutralColor;
     }
   });
-  const landlordPosition = convertToPercentage(landlordPoints / totalPoints);
-  const challengerPosition = convertToPercentage(
-    (totalPoints - challengerPoints) / totalPoints
+  const landlordPosition = convertToPercentage(
+    (totalPoints - landlordPoints) / totalPoints
   );
-  const challengerWidth = convertToPercentage(challengerPoints / totalPoints);
+  const landlordWidth = convertToPercentage(landlordPoints / totalPoints);
+  const challengerPosition = convertToPercentage(
+    challengerPoints / totalPoints
+  );
 
   return (
     <div>
-      <div className="progress-bar-neutral">
+      <div
+        style={{
+          width: "100%",
+          borderRadius: "5px",
+          backgroundColor: "lightgray",
+        }}
+      >
         <div
-          className="progress-bar-landlord"
-          style={{ width: landlordPosition }}
-        />
-        <div
-          className="progress-bar-challenger"
           style={{
-            marginTop: "-20px",
-            position: "relative",
-            left: challengerPosition,
-            width: challengerWidth,
+            width: challengerPosition,
+            height: "20px",
+            borderRadius: "5px",
+            backgroundColor: "#5bc0de",
           }}
         />
+        {!props.hideLandlordPoints && (
+          <div
+            className="progress-bar-landlord"
+            style={{
+              marginTop: "-20px",
+              position: "relative",
+              left: landlordPosition,
+              width: landlordWidth,
+              height: "20px",
+              borderRadius: "5px",
+              backgroundColor: "#d9534f",
+            }}
+          />
+        )}
       </div>
-      <CheckpointCircle
-        text={checkpoints[0]}
-        color={checkpointColors[0]}
-        position="20%"
-        marginTop="-30px"
-      />
-      <CheckpointCircle
-        text={checkpoints[1]}
-        color={checkpointColors[1]}
-        position="40%"
-        marginTop="-40px"
-      />
-      <CheckpointCircle
-        text={checkpoints[2]}
-        color={checkpointColors[2]}
-        position="60%"
-        marginTop="-40px"
-      />
-      <CheckpointCircle
-        text={checkpoints[3]}
-        color={checkpointColors[3]}
-        position="80%"
-        marginTop="-40px"
-      />
+      {props.checkpoints.map((checkpoint, i) => {
+        return (
+          <CheckpointCircle
+            key={i}
+            text={checkpoint}
+            color={checkpointColors[i]}
+            position={convertToPercentage(checkpoint / totalPoints)}
+            marginTop={i === 0 ? "-30px" : "-40px"}
+          />
+        );
+      })}
     </div>
   );
 };

--- a/frontend/src/ProgressBar.tsx
+++ b/frontend/src/ProgressBar.tsx
@@ -1,0 +1,107 @@
+import * as React from "react";
+
+interface IProps {
+  numDecks: number;
+  challengerPoints: number;
+  landlordPoints: number;
+}
+
+interface CheckpointCircleProps {
+  text: number;
+  color: string;
+  position: string;
+  marginTop: string;
+}
+
+const CheckpointCircle = (props: CheckpointCircleProps): JSX.Element => {
+  return (
+    <div
+      className="checkpoint-circle"
+      style={{
+        position: "relative",
+        left: props.position,
+        transform: "translate(-50%, 0%)",
+        backgroundColor: props.color,
+        marginTop: props.marginTop,
+      }}
+    >
+      <div className="checkpoint-circle-content">{props.text}</div>
+    </div>
+  );
+};
+
+const convertToPercentage = (proportion: number): string => {
+  return (100 * proportion).toFixed(2) + "%";
+};
+
+const ProgressBar = (props: IProps): JSX.Element => {
+  const landlordColor = "#5bc0de";
+  const challengerColor = "#d9534f";
+  const neutralColor = "lightgray";
+
+  const { numDecks, challengerPoints, landlordPoints } = props;
+  const totalPoints = numDecks * 100;
+  const checkpoints = [0.2, 0.4, 0.6, 0.8].map(
+    (proportion) => proportion * totalPoints
+  );
+  const checkpointColors = checkpoints.map((checkpoint) => {
+    if (landlordPoints >= checkpoint) {
+      return landlordColor;
+    } else if (challengerPoints >= totalPoints - checkpoint) {
+      return challengerColor;
+    } else {
+      return neutralColor;
+    }
+  });
+  const landlordPosition = convertToPercentage(landlordPoints / totalPoints);
+  const challengerPosition = convertToPercentage(
+    (totalPoints - challengerPoints) / totalPoints
+  );
+  const challengerWidth = convertToPercentage(challengerPoints / totalPoints);
+
+  return (
+    <div>
+      <div className="progress-bar-neutral">
+        <div
+          className="progress-bar-landlord"
+          style={{ width: landlordPosition }}
+        />
+        <div
+          className="progress-bar-challenger"
+          style={{
+            marginTop: "-20px",
+            position: "relative",
+            left: challengerPosition,
+            width: challengerWidth,
+          }}
+        />
+      </div>
+      <CheckpointCircle
+        text={checkpoints[0]}
+        color={checkpointColors[0]}
+        position="20%"
+        marginTop="-30px"
+      />
+      <CheckpointCircle
+        text={checkpoints[1]}
+        color={checkpointColors[1]}
+        position="40%"
+        marginTop="-40px"
+      />
+      <CheckpointCircle
+        text={checkpoints[2]}
+        color={checkpointColors[2]}
+        position="60%"
+        marginTop="-40px"
+      />
+      <CheckpointCircle
+        text={checkpoints[3]}
+        color={checkpointColors[3]}
+        position="80%"
+        marginTop="-40px"
+      />
+    </div>
+  );
+};
+
+export default ProgressBar;

--- a/frontend/src/ProgressBar.tsx
+++ b/frontend/src/ProgressBar.tsx
@@ -49,17 +49,17 @@ const convertToPercentage = (proportion: number): string => {
 };
 
 const ProgressBar = (props: IProps): JSX.Element => {
-  const landlordColor = "#5bc0de";
-  const challengerColor = "#d9534f";
+  const landlordColor = "#d9534f";
+  const challengerColor = "#5bc0de";
   const neutralColor = "lightgray";
 
   const { numDecks, challengerPoints, landlordPoints } = props;
   const totalPoints = numDecks * 100;
   const checkpointColors = props.checkpoints.map((checkpoint) => {
-    if (landlordPoints >= checkpoint) {
-      return landlordColor;
-    } else if (challengerPoints >= totalPoints - checkpoint) {
+    if (challengerPoints >= checkpoint) {
       return challengerColor;
+    } else if (landlordPoints >= totalPoints - checkpoint) {
+      return landlordColor;
     } else {
       return neutralColor;
     }
@@ -86,7 +86,7 @@ const ProgressBar = (props: IProps): JSX.Element => {
             width: challengerPosition,
             height: "20px",
             borderRadius: "5px",
-            backgroundColor: "#5bc0de",
+            backgroundColor: challengerColor,
           }}
         />
         {!props.hideLandlordPoints && (
@@ -99,7 +99,7 @@ const ProgressBar = (props: IProps): JSX.Element => {
               width: landlordWidth,
               height: "20px",
               borderRadius: "5px",
-              backgroundColor: "#d9534f",
+              backgroundColor: landlordColor,
             }}
           />
         )}

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -378,35 +378,3 @@ button.normal {
 label {
   line-height: 25px;
 }
-
-.checkpoint-circle {
-  height: 40px;
-  width: 40px;
-  border-radius: 25px;
-}
-
-.checkpoint-circle-content {
-  width: 100%;
-  height: 100%;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-}
-
-.progress-bar-neutral {
-  width: 100%;
-  border-radius: 5px;
-  background-color: lightgray;
-}
-
-.progress-bar-landlord {
-  height: 20px;
-  border-radius: 5px;
-  background-color: #5bc0de;
-}
-
-.progress-bar-challenger {
-  height: 20px;
-  border-radius: 5px;
-  background-color: #d9534f;
-}

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -378,3 +378,35 @@ button.normal {
 label {
   line-height: 25px;
 }
+
+.checkpoint-circle {
+  height: 40px;
+  width: 40px;
+  border-radius: 25px;
+}
+
+.checkpoint-circle-content {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.progress-bar-neutral {
+  width: 100%;
+  border-radius: 5px;
+  background-color: lightgray;
+}
+
+.progress-bar-landlord {
+  height: 20px;
+  border-radius: 5px;
+  background-color: #5bc0de;
+}
+
+.progress-bar-challenger {
+  height: 20px;
+  border-radius: 5px;
+  background-color: #d9534f;
+}


### PR DESCRIPTION
## Overview

Hi! I've loved playing Tractor on your website, thanks a lot for writing it! =) One addition I've always thought could be nice is to add a "progress bar" that keeps visual track of each team's points relative to the game's checkpoints. I've implemented it in this PR, but I'm a bit of a frontend noob, so please let me know what changes you'd like to see before approving!

![image](https://user-images.githubusercontent.com/14115641/105214693-564d8700-5b1e-11eb-9c23-624b69397648.png)

## Testing

- Tested locally with both Tractor and Finding Friends modes (screenshot below)
- Ran `yarn prettier --write` and `yarn lint --fix`