### PR TITLE
ProgressBar: clamp percentage to 0-100%

### DIFF
--- a/frontend/src/ProgressBar.tsx
+++ b/frontend/src/ProgressBar.tsx
@@ -50,6 +50,7 @@ const CheckpointCircle = (props: CheckpointCircleProps): JSX.Element => {
 };
 
 const convertToPercentage = (proportion: number): string => {
+  proportion = Math.max(0, Math.min(1, proportion));
   return (100 * proportion).toFixed(2) + "%";
 };
 


### PR DESCRIPTION
In some situations (e.g., someone put a ton of points on the bottom),
the number of points allocated to a team can exceed the number of points
normally allowed in the game, which will in turn cause the points
progress bar to overflow the expected bounds.

Rendering a good UI here a bit annoying, but clamping the result to
0-100% at least means the UI won't break!

Disclaimer: I have not tested this code