### PR TITLE
Rework cards to entirely use computed sizes rather than font sizes in game

### DIFF
--- a/frontend/src/AutoPlayButton.tsx
+++ b/frontend/src/AutoPlayButton.tsx
@@ -57,7 +57,7 @@ const AutoPlayButton = (props: IProps): JSX.Element => {
     }
   };
   return (
-    <button onClick={handleClick} disabled={!canSubmit}>
+    <button className="big" onClick={handleClick} disabled={!canSubmit}>
       {isCurrentPlayerTurn
         ? `Play selected cards${
             playDescription !== null ? " (" + playDescription + ")" : ""

--- a/frontend/src/BeepButton.tsx
+++ b/frontend/src/BeepButton.tsx
@@ -6,6 +6,7 @@ const BeepButton = (): JSX.Element => {
 
   return (
     <button
+      className="big"
       onClick={() =>
         confirm("Do you really want to send a beep to the current player?") &&
         send("Beep")

--- a/frontend/src/Cards.tsx
+++ b/frontend/src/Cards.tsx
@@ -100,6 +100,7 @@ const Cards = (props: IProps): JSX.Element => {
                   onClick={handleUnselect(c.card)}
                   trump={props.trump}
                   card={c.card}
+                  collapseRight={idx !== g.length - 1}
                 />
               ))}
             </div>
@@ -131,6 +132,7 @@ const Cards = (props: IProps): JSX.Element => {
                 )}
                 onClick={handleSelect(c.card)}
                 card={c.card}
+                collapseRight={idx !== g.length - 1}
                 trump={props.trump}
                 onMouseEnter={(_) => setHighlightedSuit(c.suit)}
                 onMouseLeave={(_) => setHighlightedSuit(null)}

--- a/frontend/src/Credits.tsx
+++ b/frontend/src/Credits.tsx
@@ -9,7 +9,7 @@ const contentStyle: React.CSSProperties = {
   transform: "translate(-50%, -50%)",
 };
 
-const changeLogVersion: number = 19;
+const changeLogVersion: number = 20;
 
 const ChangeLog = (): JSX.Element => {
   const [modalOpen, setModalOpen] = React.useState<boolean>(false);
@@ -59,6 +59,10 @@ const ChangeLog = (): JSX.Element => {
           you&apos;re in the game.
         </p>
         <h2>Change Log</h2>
+        <p>1/11/2023:</p>
+        <ul>
+          <li>Fixed rendering of card icons</li>
+        </ul>
         <p>1/10/2023:</p>
         <ul>
           <li>

--- a/frontend/src/Exchange.tsx
+++ b/frontend/src/Exchange.tsx
@@ -171,6 +171,7 @@ class Exchange extends React.Component<IExchangeProps, IExchangeState> {
                 trump={this.props.state.trump}
                 key={idx}
                 onClick={() => this.moveCardToHand(c)}
+                collapseRight={idx !== this.props.state.kitty.length - 1}
                 card={c}
               />
             ))}

--- a/frontend/src/LabeledPlay.tsx
+++ b/frontend/src/LabeledPlay.tsx
@@ -11,7 +11,7 @@ interface IProps {
   groupedCards?: string[][];
   moreCards?: string[];
   trump: Trump;
-  label: string;
+  label: string | JSX.Element;
   next?: number | null;
   onClick?: () => void;
 }

--- a/frontend/src/LabeledPlay.tsx
+++ b/frontend/src/LabeledPlay.tsx
@@ -24,7 +24,12 @@ const LabeledPlay = (props: IProps): JSX.Element => {
   });
 
   const cards = props.cards.map((card, idx) => (
-    <Card card={card} key={idx} trump={props.trump} />
+    <Card
+      card={card}
+      key={idx}
+      trump={props.trump}
+      collapseRight={idx !== props.cards.length - 1}
+    />
   ));
 
   const groupedCards =
@@ -38,6 +43,7 @@ const LabeledPlay = (props: IProps): JSX.Element => {
                     trump={props.trump}
                     card={card}
                     key={`${gidx}-${idx}`}
+                    collapseRight={idx !== c.length - 1}
                   />
                 )
               )}
@@ -64,7 +70,13 @@ const LabeledPlay = (props: IProps): JSX.Element => {
       {props.moreCards !== undefined && props.moreCards.length > 0 ? (
         <div className="play more">
           {props.moreCards.map((card, idx) => (
-            <Card trump={props.trump} card={card} key={idx} smaller={true} />
+            <Card
+              trump={props.trump}
+              card={card}
+              key={idx}
+              smaller={true}
+              collapseRight={idx !== props.moreCards.length - 1}
+            />
           ))}
         </div>
       ) : null}

--- a/frontend/src/Play.tsx
+++ b/frontend/src/Play.tsx
@@ -271,11 +271,12 @@ const Play = (props: IProps): JSX.Element => {
         isCurrentPlayerTurn={isCurrentPlayerTurn}
       />
       {playPhase.propagated.play_takeback_policy === "AllowPlayTakeback" && (
-        <button onClick={takeBackCards} disabled={!canTakeBack}>
+        <button className="big" onClick={takeBackCards} disabled={!canTakeBack}>
           Take back last play
         </button>
       )}
       <button
+        className="big"
         onClick={endTrick}
         disabled={
           playPhase.trick.player_queue.length > 0 || playPhase.game_ended_early
@@ -285,6 +286,7 @@ const Play = (props: IProps): JSX.Element => {
       </button>
       {canEndGameEarly && (
         <button
+          className="big"
           onClick={() => {
             confirm(
               "Do you want to end the game early? There may still be points in the bottom..."
@@ -294,7 +296,11 @@ const Play = (props: IProps): JSX.Element => {
           End game early
         </button>
       )}
-      {canFinish && <button onClick={startNewGame}>Finish game</button>}
+      {canFinish && (
+        <button className="big" onClick={startNewGame}>
+          Finish game
+        </button>
+      )}
       <BeepButton />
       {canFinish && !noCardsLeft && (
         <div>
@@ -337,7 +343,7 @@ const Play = (props: IProps): JSX.Element => {
                       evt.preventDefault();
                       setGrouping([g]);
                     }}
-                    className="normal"
+                    className="big"
                   >
                     {g.description}
                   </button>
@@ -421,6 +427,7 @@ const TrickFormatHelper = (props: {
   return (
     <>
       <button
+        className="big"
         onClick={(evt) => {
           evt.preventDefault();
           setModalOpen(true);

--- a/frontend/src/SvgCard.tsx
+++ b/frontend/src/SvgCard.tsx
@@ -230,6 +230,7 @@ const FourColorCards: {
 
 interface IProps {
   card: string;
+  height?: number;
   smaller?: boolean;
   fourColor: boolean;
 }
@@ -239,7 +240,7 @@ const SvgCard = (props: IProps): JSX.Element => {
   return React.createElement(
     (props.fourColor ? FourColorCards : NormalCards)[props.card],
     {
-      height: props.smaller ? 95 : 120,
+      height: props.height || 120,
     }
   );
   /* eslint-enable */

--- a/frontend/src/Trick.tsx
+++ b/frontend/src/Trick.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 
+import ReactTooltip from "react-tooltip";
 import classNames from "classnames";
 
 import LabeledPlay from "./LabeledPlay";
@@ -77,7 +78,29 @@ const TrickE = (props: IProps): JSX.Element => {
         const winning = props.trick.current_winner === id;
         const better = betterPlayer === id;
         const cards = id in playedByID ? playedByID[id].cards : blankCards;
-        const suffix = winning ? " (!)" : better ? " (-)" : "";
+        const suffix = winning ? (
+          <>
+            {" "}
+            <ReactTooltip id="winningTip" place="bottom" effect="solid">
+              Current winner of trick
+            </ReactTooltip>
+            <span data-tip data-for="winningTip">
+              (<code>!</code>)
+            </span>
+          </>
+        ) : better ? (
+          <>
+            {" "}
+            <ReactTooltip id="betterTip" place="bottom" effect="solid">
+              First player who can prevent the attempted throw
+            </ReactTooltip>
+            <span data-tip data-for="betterTip">
+              (<code>-</code>)
+            </span>
+          </>
+        ) : (
+          <></>
+        );
 
         const className = classNames(
           winning
@@ -96,9 +119,11 @@ const TrickE = (props: IProps): JSX.Element => {
             key={id}
             id={id}
             label={
-              namesById[id] +
-              (id === props.landlord ? " " + props.landlord_suffix : "") +
-              suffix
+              <>
+                {namesById[id] +
+                  (id === props.landlord ? " " + props.landlord_suffix : "")}
+                {suffix}
+              </>
             }
             className={className}
             groupedCards={cardsFromMappingByID[id]}

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -73,15 +73,14 @@ button.normal {
 }
 
 .card {
-  font-size: 8em;
   display: inline-block;
   cursor: pointer;
-  margin-right: -0.35em;
   background: transparent;
   user-select: none;
   font-family: "Apple Symbols", "Segoe UI Symbol", "Symbola", "DejaVu Sans",
     system;
   position: relative;
+  margin-top: 20px;
 }
 
 .card.highlighted {
@@ -113,7 +112,6 @@ button.normal {
   position: absolute;
   font-size: initial;
   left: 0.35em;
-  bottom: 2.6em;
   z-index: 1;
   background: #fff;
   width: 1.5em;
@@ -124,7 +122,6 @@ button.normal {
 }
 
 .more .card .card-label {
-  bottom: 1.95em;
 }
 
 .hand .unselected-cards.unclickable .card {
@@ -132,43 +129,31 @@ button.normal {
 }
 
 .hand .unselected-cards .card {
-  margin-top: 0.2em;
+  margin-top: 30px;
 }
 
 .hand .unselected-cards .card:hover svg {
-  transform: translateY(-0.15em);
+  transform: translateY(-20px);
 }
 
 .hand .unselected-cards .card:hover .card-label {
-  transform: translateY(-1.2em);
+  transform: translateY(-20px);
 }
 
 .card .card-icon {
   position: absolute;
   font-size: initial;
   left: 0.35em;
-  top: 0.5em;
   z-index: 1;
 }
 
-.more .card .card-icon {
-  top: -0.1em;
-}
-
-.card.svg .card-icon {
-  top: -0.16em;
-}
-
-.more .card.svg .card-icon {
-  top: -0.6em;
-}
-
 .hand .unselected-cards .card:hover .card-icon {
-  transform: translateY(-1.2em);
+  transform: translateY(-20px);
 }
 
 .kitty {
-  margin-top: 40px;
+  margin-top: 20px;
+  margin-bottom: 20px;
 }
 
 .always-show-labels .card .card-label,
@@ -214,10 +199,6 @@ button.normal {
 .dark-mode .card.notify {
   animation: blinkingTextDark 1.5s 1;
   color: #fff;
-}
-
-.card:last-child {
-  margin-right: 0;
 }
 
 .♢ {
@@ -387,6 +368,7 @@ button.normal {
   display: inline-block;
   padding: 10px;
   border: 1px solid #000;
+  margin-bottom: 20px;
 }
 
 .dark-mode .labeled-play {
@@ -414,10 +396,6 @@ button.normal {
   box-shadow: inset 0px 0px 0px 2px #bb0313;
 }
 
-.labeled-play .more .card {
-  font-size: 6em;
-}
-
 .always-show-labels .more .card.svg .card-label,
 .more .card.svg:hover .card-label {
   bottom: 1.8em;
@@ -425,6 +403,7 @@ button.normal {
 
 .labeled-play .play {
   display: inline-block;
+  padding-bottom: 20px;
 }
 
 .labeled-play .play + .play {
@@ -470,4 +449,13 @@ button.normal {
 
 label {
   line-height: 25px;
+}
+
+/* used by rules.html */
+.rules .card {
+  font-size: 8em;
+  margin-right: -0.4em;
+}
+.rules .card:last-child {
+  margin-right: 0;
 }

--- a/frontend/static/rules.html
+++ b/frontend/static/rules.html
@@ -8,7 +8,7 @@
           .card { background: #fff; height: inherit; }
         </style>
     </head>
-  <body id="body">
+  <body id="body" class="rules">
     <h1>Rules for 升级 and 找朋友</h1>
     
     <p>


### PR DESCRIPTION
Due to incomplete migrations, the card styling was partly using font sizing (`8em`) and a carefully computed bound around the card glyph itself (`computeCardBound`). This is tricky on a per-OS basis because the default fonts on Windows and macOS and Linux render cards with very different bounding boxes. Not previously too much of an issue since the impact of the change is mostly to the upper bound of the card, but with the new card icons this becomes problematic.