### PR TITLE
Performance optimizations for trick-format matching

### DIFF
--- a/core/examples/simulate_play.rs
+++ b/core/examples/simulate_play.rs
@@ -9,6 +9,7 @@ use shengji_core::{
     settings::{FriendSelection, GameModeSettings},
 };
 use shengji_mechanics::{
+    ordered_card::OrderedCard,
     trick::{TractorRequirements, TrickUnit, UnitLike},
     types::{Card, EffectiveSuit, Number, Suit},
 };
@@ -196,26 +197,24 @@ fn main() {
                         let matching_play = trick_format
                             .decomposition(Default::default())
                             .filter_map(|format| {
-                                let (playable, units) = UnitLike::check_play(
-                                    trick_format.trump(),
-                                    available_cards.iter().copied(),
+                                let mut playable = UnitLike::check_play(
+                                    OrderedCard::make_map(
+                                        available_cards.iter().copied(),
+                                        trick_format.trump(),
+                                    ),
                                     format.iter().cloned(),
                                     s.propagated().trick_draw_policy(),
                                 );
-                                if playable {
-                                    Some(
-                                        units
-                                            .into_iter()
-                                            .flat_map(|x| {
-                                                x.into_iter().flat_map(|(card, count)| {
-                                                    std::iter::repeat(card.card).take(count)
-                                                })
+
+                                playable.next().map(|u| {
+                                    u.into_iter()
+                                        .flat_map(|x| {
+                                            x.into_iter().flat_map(|(card, count)| {
+                                                std::iter::repeat(card.card).take(count)
                                             })
-                                            .collect::<Vec<_>>(),
-                                    )
-                                } else {
-                                    None
-                                }
+                                        })
+                                        .collect::<Vec<_>>()
+                                })
                             })
                             .next();
 

--- a/frontend/src/Credits.tsx
+++ b/frontend/src/Credits.tsx
@@ -9,7 +9,7 @@ const contentStyle: React.CSSProperties = {
   transform: "translate(-50%, -50%)",
 };
 
-const changeLogVersion: number = 20;
+const changeLogVersion: number = 21;
 
 const ChangeLog = (): JSX.Element => {
   const [modalOpen, setModalOpen] = React.useState<boolean>(false);
@@ -59,6 +59,11 @@ const ChangeLog = (): JSX.Element => {
           you&apos;re in the game.
         </p>
         <h2>Change Log</h2>
+        <p>1/18/2023:</p>
+        <ul>
+          <li>Fixed performance issue when playing tricks with many cards</li>
+          <li>Added suggested play button</li>
+        </ul>
         <p>1/11/2023:</p>
         <ul>
           <li>Fixed rendering of card icons</li>

--- a/frontend/src/Play.tsx
+++ b/frontend/src/Play.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import ReactTooltip from "react-tooltip";
 import * as ReactModal from "react-modal";
 import {
   PlayPhase,
@@ -126,22 +127,35 @@ const Play = (props: IProps): JSX.Element => {
   const lastPlay =
     playPhase.trick.played_cards[playPhase.trick.played_cards.length - 1];
 
-  const isCurrentPlayerTurn = currentPlayer.id === nextPlayer;
-  let canPlay = false;
-  if (!isSpectator) {
-    canPlay = canPlayCards({
-      trick: playPhase.trick,
-      id: currentPlayer.id,
-      hands: playPhase.hands,
-      cards: selected,
-      trick_draw_policy: playPhase.propagated.trick_draw_policy,
-    });
-    // In order to play the first trick, the grouping must be disambiguated!
-    if (lastPlay === undefined) {
-      canPlay = canPlay && grouping.length === 1;
+  const canPlay = React.useMemo(() => {
+    if (!isSpectator) {
+      let playable = canPlayCards({
+        trick: playPhase.trick,
+        id: currentPlayer.id,
+        hands: playPhase.hands,
+        cards: selected,
+        trick_draw_policy: playPhase.propagated.trick_draw_policy,
+      });
+      // In order to play the first trick, the grouping must be disambiguated!
+      if (lastPlay === undefined) {
+        playable = playable && grouping.length === 1;
+      }
+      playable = playable && !playPhase.game_ended_early;
+      return playable;
     }
-  }
-  canPlay = canPlay && !playPhase.game_ended_early;
+  }, [
+    playPhase.trick,
+    currentPlayer.id,
+    playPhase.hands,
+    selected,
+    playPhase.propagated.trick_draw_policy,
+    isSpectator,
+    lastPlay,
+    playPhase.game_ended_early,
+    grouping,
+  ]);
+
+  const isCurrentPlayerTurn = currentPlayer.id === nextPlayer;
   const canTakeBack =
     lastPlay !== undefined &&
     currentPlayer.id === lastPlay.id &&
@@ -325,6 +339,16 @@ const Play = (props: IProps): JSX.Element => {
               hands={playPhase.hands}
               playerId={currentPlayer.id}
               trickDrawPolicy={playPhase.propagated.trick_draw_policy}
+              setSelected={(newSelected) => {
+                setSelected(newSelected);
+                setGrouping(
+                  findViablePlays(
+                    playPhase.trump,
+                    playPhase.propagated.tractor_requirements,
+                    newSelected
+                  )
+                );
+              }}
             />
           ) : null}
           {lastPlay === undefined &&
@@ -407,26 +431,123 @@ const Play = (props: IProps): JSX.Element => {
   );
 };
 
+const HelperContents = (props: {
+  format: TrickFormat;
+  hands: Hands;
+  playerId: number;
+  trickDrawPolicy: TrickDrawPolicy;
+  setSelected: (selected: string[]) => void;
+}): JSX.Element => {
+  const { decomposeTrickFormat } = React.useContext(WasmContext);
+  const decomp = React.useMemo(
+    () =>
+      decomposeTrickFormat({
+        trick_format: props.format,
+        hands: props.hands,
+        player_id: props.playerId,
+        trick_draw_policy: props.trickDrawPolicy,
+      }),
+    [props.format, props.hands, props.playerId, props.trickDrawPolicy]
+  );
+  const trickSuit = props.format.suit;
+  const bestMatch = decomp.findIndex((d) => d.playable.length > 0);
+  const modalContents = (
+    <>
+      <p>
+        In order to win, you have to play {decomp[0].description} in {trickSuit}
+      </p>
+      {decomp[0].playable.length > 0 && (
+        <p>
+          It looks like you are able to match this format, e.g. with{" "}
+          <span
+            style={{ cursor: "pointer" }}
+            onClick={() => props.setSelected(decomp[0].playable)}
+          >
+            {decomp[0].playable.map((c, cidx) => (
+              <InlineCard key={cidx} card={c} />
+            ))}
+          </span>
+        </p>
+      )}
+
+      {decomp.length > 1 && props.trickDrawPolicy !== "NoFormatBasedDraw" && (
+        <>
+          <p>
+            If you can&apos;t play that, but you <em>can</em> play one of the
+            following, you have to play it
+          </p>
+          <ol>
+            {decomp.slice(1).map((d, idx) => (
+              <li
+                key={idx}
+                style={{
+                  fontWeight: idx === bestMatch - 1 ? "bold" : "normal",
+                }}
+              >
+                {d.description} in {trickSuit}
+                {idx === bestMatch - 1 && (
+                  <>
+                    {" "}
+                    <span
+                      style={{ cursor: "pointer" }}
+                      onClick={() => props.setSelected(d.playable)}
+                    >
+                      (for example:{" "}
+                      {d.playable.map((c, cidx) => (
+                        <InlineCard key={cidx} card={c} />
+                      ))}
+                      )
+                    </span>
+                  </>
+                )}
+              </li>
+            ))}
+          </ol>
+        </>
+      )}
+      <p
+        style={{
+          fontWeight: bestMatch < 0 ? "bold" : "normal",
+        }}
+      >
+        Otherwise, you have to play as many {trickSuit} as you can. The
+        remaining cards can be anything.
+      </p>
+      {trickSuit !== "Trump" && (
+        <p>
+          If you have no cards in {trickSuit}, you can play{" "}
+          {decomp[0].description} in Trump to potentially win the trick.
+        </p>
+      )}
+    </>
+  );
+
+  return modalContents;
+};
+
 const TrickFormatHelper = (props: {
   format: TrickFormat;
   hands: Hands;
   playerId: number;
   trickDrawPolicy: TrickDrawPolicy;
+  setSelected: (selected: string[]) => void;
 }): JSX.Element => {
-  const [modalOpen, setModalOpen] = React.useState<boolean>(false);
   const { decomposeTrickFormat } = React.useContext(WasmContext);
-  const decomp = decomposeTrickFormat({
-    trick_format: props.format,
-    hands: props.hands,
-    player_id: props.playerId,
-    trick_draw_policy: props.trickDrawPolicy,
-  });
-  const trickSuit = props.format.suit;
-  const bestMatch = decomp.findIndex((d) => d.playable.length > 0);
+  const [modalOpen, setModalOpen] = React.useState<boolean>(false);
+  const [message, setMessage] = React.useState<string>("");
+
+  React.useEffect(() => {
+    setMessage("");
+  }, [props.hands]);
 
   return (
     <>
+      <ReactTooltip id="helpTip" place="top" effect="solid">
+        Get help on what you can play
+      </ReactTooltip>
       <button
+        data-tip
+        data-for="helpTip"
         className="big"
         onClick={(evt) => {
           evt.preventDefault();
@@ -435,6 +556,37 @@ const TrickFormatHelper = (props: {
       >
         ?
       </button>
+      <ReactTooltip id="suggestTip" place="top" effect="solid">
+        Suggest a play (not guaranteed to succeed)
+      </ReactTooltip>
+      <button
+        data-tip
+        data-for="suggestTip"
+        className="big"
+        onClick={(evt) => {
+          evt.preventDefault();
+          const decomp = decomposeTrickFormat({
+            trick_format: props.format,
+            hands: props.hands,
+            player_id: props.playerId,
+            trick_draw_policy: props.trickDrawPolicy,
+          });
+          const bestMatch = decomp.findIndex((d) => d.playable.length > 0);
+          if (bestMatch >= 0) {
+            props.setSelected(decomp[bestMatch].playable);
+            setMessage("success");
+            setTimeout(() => setMessage(""), 500);
+          } else {
+            setMessage("cannot suggest a play");
+            setTimeout(() => setMessage(""), 2000);
+          }
+        }}
+      >
+        ✨
+      </button>
+      <span style={{ color: "red" }} onClick={() => setMessage("")}>
+        {message}
+      </span>
       <ReactModal
         isOpen={modalOpen}
         onRequestClose={() => setModalOpen(false)}
@@ -442,58 +594,17 @@ const TrickFormatHelper = (props: {
         shouldCloseOnEsc
         style={{ content: contentStyle }}
       >
-        <p>
-          In order to win, you have to play {decomp[0].description} in{" "}
-          {trickSuit}
-        </p>
-        {decomp[0].playable.length > 0 && (
-          <p>
-            It looks like you are able to match this format, e.g. with
-            {decomp[0].playable.map((c, cidx) => (
-              <InlineCard key={cidx} card={c} />
-            ))}
-          </p>
-        )}
-
-        {decomp.length > 1 && props.trickDrawPolicy !== "NoFormatBasedDraw" && (
-          <>
-            <p>
-              If you can&apos;t play that, but you <em>can</em> play one of the
-              following, you have to play it
-            </p>
-            <ol>
-              {decomp.slice(1).map((d, idx) => (
-                <li
-                  key={idx}
-                  style={{
-                    fontWeight: idx === bestMatch - 1 ? "bold" : "normal",
-                  }}
-                >
-                  {d.description} in {trickSuit}
-                  {idx === bestMatch - 1 && (
-                    <>
-                      {" "}
-                      (for example:{" "}
-                      {d.playable.map((c, cidx) => (
-                        <InlineCard key={cidx} card={c} />
-                      ))}
-                      )
-                    </>
-                  )}
-                </li>
-              ))}
-            </ol>
-          </>
-        )}
-        <p>
-          Otherwise, you have to play as many {trickSuit} as you can. The
-          remaining cards can be anything.
-        </p>
-        {trickSuit !== "Trump" && (
-          <p>
-            If you have no cards in {trickSuit}, you can play{" "}
-            {decomp[0].description} in Trump to potentially win the trick.
-          </p>
+        {modalOpen && (
+          <HelperContents
+            format={props.format}
+            hands={props.hands}
+            playerId={props.playerId}
+            trickDrawPolicy={props.trickDrawPolicy}
+            setSelected={(sel) => {
+              props.setSelected(sel);
+              setModalOpen(false);
+            }}
+          />
         )}
       </ReactModal>
     </>

--- a/frontend/src/gen-types.d.ts
+++ b/frontend/src/gen-types.d.ts
@@ -779,6 +779,7 @@ export interface DecomposeTrickFormatResponse {
 export interface DecomposedTrickFormat {
   description: string;
   format: UnitLike[];
+  more_than_one: boolean;
   playable: Card[];
   [k: string]: unknown;
 }

--- a/frontend/src/gen-types.schema.json
+++ b/frontend/src/gen-types.schema.json
@@ -842,7 +842,7 @@
     },
     "DecomposedTrickFormat": {
       "type": "object",
-      "required": ["description", "format", "playable"],
+      "required": ["description", "format", "more_than_one", "playable"],
       "properties": {
         "description": {
           "type": "string"
@@ -852,6 +852,9 @@
           "items": {
             "$ref": "#/definitions/UnitLike"
           }
+        },
+        "more_than_one": {
+          "type": "boolean"
         },
         "playable": {
           "type": "array",

--- a/mechanics/src/format_match.rs
+++ b/mechanics/src/format_match.rs
@@ -1,0 +1,524 @@
+use std::collections::{BTreeMap, HashSet, VecDeque};
+use std::iter::Peekable;
+
+use anyhow::Error;
+
+use crate::ordered_card::{AdjacentTupleSizes, MatchingCards, OrderedCard};
+
+pub fn find_format_matches(
+    format: Vec<AdjacentTupleSizes>,
+    cards: BTreeMap<OrderedCard, usize>,
+) -> impl Iterator<Item = Vec<MatchingCards>> {
+    let mut queue = VecDeque::new();
+
+    let (requirements, init) = FormatMatchState::empty(&format);
+    queue.push_back(QueueItem::State(init));
+
+    FormatMatchIterator {
+        format: requirements,
+        format_seq: format,
+        queue,
+        cards,
+        visited: HashSet::new(),
+    }
+}
+
+#[derive(Debug, Hash, Eq, PartialEq, Clone)]
+struct FormatMatchState {
+    /// We use this convulated matching so that FormatMatchState is the same
+    /// regardless of the order in which we fill the requested formats, but not
+    /// the same if we fill them with similar-but-not-identical values.
+    /// This is a map from:
+    /// format-request to
+    ///     card mapping to
+    ///         number of times we used that card mapping
+    assigned_formats_so_far: BTreeMap<AdjacentTupleSizes, BTreeMap<MatchingCards, usize>>,
+}
+
+impl FormatMatchState {
+    fn empty(format: &[AdjacentTupleSizes]) -> (BTreeMap<AdjacentTupleSizes, usize>, Self) {
+        let mut required_formats = BTreeMap::new();
+        for f in format {
+            *required_formats.entry(f.clone()).or_default() += 1;
+        }
+
+        (
+            required_formats,
+            FormatMatchState {
+                assigned_formats_so_far: BTreeMap::new(),
+            },
+        )
+    }
+
+    fn with_additional_formats(
+        &self,
+        fmt: impl IntoIterator<Item = Vec<(OrderedCard, usize)>>,
+    ) -> Self {
+        let mut s = self.clone();
+        for fmt in fmt {
+            let adj_tup = fmt.iter().map(|(_, v)| *v).collect();
+            *s.assigned_formats_so_far
+                .entry(adj_tup)
+                .or_default()
+                .entry(fmt)
+                .or_default() += 1;
+        }
+        s
+    }
+
+    fn contained_cards(&self) -> BTreeMap<OrderedCard, usize> {
+        let mut cards = BTreeMap::new();
+
+        for v in self.assigned_formats_so_far.values() {
+            for (vv, ct) in v {
+                for (card, count) in vv {
+                    *cards.entry(*card).or_default() += *count * ct;
+                }
+            }
+        }
+
+        cards
+    }
+
+    fn into_matching_cards(
+        mut self,
+        format_seq: &[AdjacentTupleSizes],
+    ) -> Result<Vec<MatchingCards>, Error> {
+        let mut output = Vec::with_capacity(format_seq.len());
+
+        for adj_req in format_seq {
+            let options = self
+                .assigned_formats_so_far
+                .get_mut(adj_req)
+                .ok_or_else(|| anyhow::anyhow!("Missing requested format bucket"))?;
+
+            let v = options
+                .keys()
+                .rev()
+                .next()
+                .ok_or_else(|| anyhow::anyhow!("No remaining matchings for format"))?
+                .clone();
+
+            let ct = options.get_mut(&v).unwrap();
+            if *ct == 1 {
+                options.remove(&v);
+            } else {
+                *ct -= 1;
+            }
+
+            output.push(v);
+        }
+
+        Ok(output)
+    }
+}
+
+enum QueueItem {
+    State(FormatMatchState),
+    Enqueue(Peekable<Box<dyn Iterator<Item = FormatMatchState>>>),
+}
+
+struct FormatMatchIterator {
+    format: BTreeMap<AdjacentTupleSizes, usize>,
+    format_seq: Vec<AdjacentTupleSizes>,
+    cards: BTreeMap<OrderedCard, usize>,
+    visited: HashSet<FormatMatchState>,
+    queue: VecDeque<QueueItem>,
+}
+
+impl FormatMatchIterator {
+    /// Compute the remaining un-matched requests.
+    ///
+    /// Returns the number of remaining matches needed for the request, along
+    /// with the request.
+    fn remaining<'a, 'b: 'a>(
+        &'a self,
+        state: &'b FormatMatchState,
+    ) -> impl Iterator<Item = (&'a AdjacentTupleSizes, usize)> + 'a {
+        self.format.iter().flat_map(|(shape, count)| {
+            // we need `count` values
+            let filled = state
+                .assigned_formats_so_far
+                .get(shape)
+                .map(|c| c.values().sum::<usize>())
+                .unwrap_or_default();
+            if filled < *count {
+                Some((shape, *count - filled))
+            } else {
+                None
+            }
+        })
+    }
+
+    fn find_possible_tractors(
+        &self,
+        r: &AdjacentTupleSizes,
+        c_ct: &impl Fn(OrderedCard) -> usize,
+    ) -> Vec<Vec<(OrderedCard, usize)>> {
+        assert!(r.len() > 1);
+        let mut to_append = vec![];
+        for card in self
+            .cards
+            .iter()
+            .rev()
+            .filter(|(_, ct)| **ct >= r[0])
+            .map(|(c, _)| *c)
+        {
+            // Do a small DFS to find the sequential adjacent tuples
+            let mut rr = r.clone();
+            rr.reverse();
+            let mut stk = vec![(card, rr, vec![])];
+
+            while let Some((next_card, mut remaining_tuples, mut seq_so_far)) = stk.pop() {
+                let ct = self.cards.get(&next_card).copied().unwrap_or_default() - c_ct(next_card);
+                let next = remaining_tuples.pop().unwrap();
+                if ct < next {
+                    continue;
+                }
+                seq_so_far.push((next_card, next));
+                if remaining_tuples.is_empty() {
+                    to_append.push(seq_so_far);
+                } else {
+                    // We may need to examine multiple potential
+                    // successors in the case of the trump number
+                    // outside the trump suit -- e.g. if the trump
+                    // number is 2, there are three potential 2x2
+                    // tractors starting at A.
+                    for s in next_card.successor() {
+                        stk.push((s, remaining_tuples.clone(), seq_so_far.clone()));
+                    }
+                }
+            }
+        }
+        to_append
+    }
+}
+
+impl Iterator for FormatMatchIterator {
+    type Item = Vec<MatchingCards>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        while let Some(qi) = self.queue.pop_front() {
+            match qi {
+                QueueItem::State(n) => {
+                    if self.visited.contains(&n) {
+                        continue;
+                    }
+                    self.visited.insert(n.clone());
+
+                    let contained_cards = n.contained_cards();
+                    let c_ct = |c| contained_cards.get(&c).copied().unwrap_or_default();
+
+                    let remaining = self.remaining(&n).collect::<Vec<_>>();
+                    if remaining.is_empty() {
+                        let cards = n.into_matching_cards(&self.format_seq).unwrap();
+                        return Some(cards);
+                    }
+                    let expansion = remaining
+                        .into_iter()
+                        .map(|(r, copies)| {
+                            // If it's not complete, for each incomplete format, try filling it
+                            // in for each possible variant -- we'll end up filling variants in
+                            // all possible orders.
+
+                            if r.is_empty() {
+                                // Not supposed to happen
+                                unreachable!("Got an empty tuple request!");
+                            }
+
+                            // Special case tractor handling, because tractors can overlap (so using combinations is not ideal)
+                            if r.len() > 1 {
+                                let possible_tractors = self.find_possible_tractors(r, &c_ct);
+                                (
+                                    possible_tractors
+                                        .into_iter()
+                                        .map(|t| (t, 1))
+                                        .collect::<Vec<_>>(),
+                                    1,
+                                )
+                            } else {
+                                // For tuples, they're guaranteed not to overlap, so we can use
+                                // combinations helpers to speed things up by simultaneously filling in
+                                // more than one at a time.
+                                (
+                                    self.cards
+                                        .iter()
+                                        .rev()
+                                        .map(|(c, ct)| (vec![(*c, r[0])], (ct - c_ct(*c)) / r[0]))
+                                        .filter(|(_, ct)| *ct > 0)
+                                        .collect(),
+                                    copies,
+                                )
+                            }
+                        })
+                        .collect::<Vec<_>>();
+                    // We should consider expansion if and only if all remaining
+                    // components are satisfiable, since only fully satisfied records are produced.
+                    //
+                    // expansion contains one element per `remaining`, where each element is
+                    // (
+                    //   [
+                    //     (option1, multiplicity1),
+                    //     (option2, multiplicity2),
+                    //     ...
+                    //   ],
+                    //   required_count
+                    // )
+
+                    if expansion
+                        .iter()
+                        .all(|(e, c)| e.iter().map(|(_, ct)| ct).sum::<usize>() >= *c)
+                    {
+                        // If there are multiple requested copies of the potential
+                        // expansion, try to move multiple along at once.
+                        for (e, ct) in expansion {
+                            let n_ = n.clone();
+                            let e_ = e.clone();
+                            let iter = crate::multiset_iter::multiset_k_combination_iter(
+                                (0..e.len()).collect::<Vec<_>>(),
+                                move |idx| e[*idx].1,
+                                ct,
+                            )
+                            .map(move |combination| {
+                                let assignments: Vec<_> = combination
+                                    .into_iter()
+                                    .flat_map(|(idx, multiplicity)| {
+                                        (0..multiplicity)
+                                            .map(|_| e_[idx].0.clone())
+                                            .collect::<Vec<_>>()
+                                    })
+                                    .collect();
+                                n_.with_additional_formats(assignments)
+                            });
+
+                            let iter: Box<dyn Iterator<Item = FormatMatchState>> = Box::new(iter);
+                            self.queue.push_back(QueueItem::Enqueue(iter.peekable()));
+                        }
+                    }
+                }
+                QueueItem::Enqueue(mut iter) => {
+                    if let Some(next) = iter.next() {
+                        if iter.peek().is_some() {
+                            self.queue.push_front(QueueItem::Enqueue(iter));
+                        }
+                        if !self.visited.contains(&next) {
+                            self.queue.push_front(QueueItem::State(next));
+                        }
+                    }
+                }
+            }
+        }
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use crate::ordered_card::OrderedCard;
+    use crate::types::{cards::*, Card, Number, Suit, Trump};
+
+    use super::find_format_matches;
+
+    const TRUMP: Trump = Trump::Standard {
+        number: Number::Four,
+        suit: Suit::Spades,
+    };
+    macro_rules! oc {
+        ($card:expr) => {
+            OrderedCard {
+                card: $card,
+                trump: TRUMP,
+            }
+        };
+    }
+
+    #[test]
+    fn test_tuple_format_match() {
+        let counts: BTreeMap<_, _> = vec![
+            (oc!(S_2), 2),
+            (oc!(S_3), 3),
+            (oc!(S_5), 3),
+            (oc!(Card::BigJoker), 1),
+        ]
+        .into_iter()
+        .collect();
+
+        let v = find_format_matches(vec![vec![1]], counts.clone()).collect::<Vec<_>>();
+
+        assert_eq!(
+            v,
+            vec![
+                vec![vec![(oc!(Card::BigJoker), 1)]],
+                vec![vec![(oc!(S_5), 1)]],
+                vec![vec![(oc!(S_3), 1)]],
+                vec![vec![(oc!(S_2), 1)]],
+            ]
+        );
+
+        let v = find_format_matches(vec![vec![2]], counts).collect::<Vec<_>>();
+
+        assert_eq!(
+            v,
+            vec![
+                vec![vec![(oc!(S_5), 2)]],
+                vec![vec![(oc!(S_3), 2)]],
+                vec![vec![(oc!(S_2), 2)]],
+            ]
+        );
+    }
+
+    #[test]
+    fn test_multiple_tuple_format_match() {
+        let counts: BTreeMap<_, _> = vec![
+            (oc!(S_2), 2),
+            (oc!(S_3), 3),
+            (oc!(S_5), 3),
+            (oc!(Card::BigJoker), 1),
+        ]
+        .into_iter()
+        .collect();
+
+        let v = find_format_matches(vec![vec![1], vec![1]], counts.clone()).collect::<Vec<_>>();
+        assert_eq!(
+            v[0],
+            vec![vec![(oc!(Card::BigJoker), 1)], vec![(oc!(S_5), 1)]]
+        );
+        // There are 9 unique choices of two cards:
+        // HJ, 5
+        // HJ, 3
+        // HJ, 2
+        // 5, 5
+        // 5, 3
+        // 5, 2
+        // 3, 3
+        // 3, 2
+        // 2, 2
+        assert_eq!(v.len(), 9);
+
+        let v = find_format_matches(vec![vec![2], vec![2]], counts).collect::<Vec<_>>();
+
+        // There are 3 unique choices of two pairsA
+        // 55, 33
+        // 55, 22
+        // 33, 22
+        assert_eq!(v[0], vec![vec![(oc!(S_5), 2)], vec![(oc!(S_3), 2)]]);
+        assert_eq!(v.len(), 3);
+    }
+
+    #[test]
+    fn test_tractor_format_match() {
+        let counts = vec![
+            (oc!(S_2), 2),
+            (oc!(S_3), 3),
+            (oc!(S_5), 3),
+            (oc!(Card::BigJoker), 1),
+        ]
+        .into_iter()
+        .collect();
+
+        let v = find_format_matches(vec![vec![2, 2]], counts).collect::<Vec<_>>();
+
+        assert_eq!(
+            v,
+            vec![
+                vec![vec![(oc!(S_3), 2), (oc!(S_5), 2)]],
+                vec![vec![(oc!(S_2), 2), (oc!(S_3), 2)]],
+            ]
+        );
+    }
+
+    #[test]
+    fn test_multiple_tractor_format_match() {
+        let counts = vec![
+            (oc!(S_2), 4),
+            (oc!(S_3), 4),
+            (oc!(S_5), 4),
+            (oc!(S_6), 4),
+            (oc!(Card::BigJoker), 1),
+        ]
+        .into_iter()
+        .collect();
+
+        let v = find_format_matches(vec![vec![2, 2], vec![2, 2]], counts).collect::<Vec<_>>();
+
+        assert_eq!(
+            v[0],
+            vec![
+                vec![(oc!(S_5), 2), (oc!(S_6), 2)],
+                vec![(oc!(S_5), 2), (oc!(S_6), 2)]
+            ]
+        );
+        // 5566, 5566
+        // 5566, 3355
+        // 5566, 2233
+        // 3355, 3355
+        // 3355, 2233
+        // 2233, 2233
+        assert_eq!(v.len(), 6);
+    }
+
+    #[test]
+    fn test_very_large_tractor_throw() {
+        let counts = vec![
+            (oc!(S_2), 10),
+            (oc!(S_3), 10),
+            (oc!(S_5), 10),
+            (oc!(S_6), 10),
+            (oc!(Card::BigJoker), 4),
+        ]
+        .into_iter()
+        .collect();
+        let fmt = vec![vec![4, 4], vec![3, 3], vec![1], vec![3]];
+
+        let v = find_format_matches(fmt, counts).collect::<Vec<_>>();
+
+        assert_eq!(
+            v[0],
+            vec![
+                vec![(oc!(S_5), 4), (oc!(S_6), 4)],
+                vec![(oc!(S_5), 3), (oc!(S_6), 3)],
+                vec![(oc!(Card::BigJoker), 1)],
+                vec![(oc!(Card::BigJoker), 3)],
+            ]
+        );
+        assert_eq!(v.len(), 215);
+    }
+
+    #[test]
+    fn test_really_long_silly_requirements() {
+        let counts = vec![
+            (oc!(S_9), 10),
+            (oc!(S_10), 10),
+            (oc!(S_J), 10),
+            (oc!(S_Q), 10),
+            (oc!(S_K), 10),
+            (oc!(S_A), 10),
+            (oc!(Card::SmallJoker), 4),
+            (oc!(Card::BigJoker), 4),
+        ]
+        .into_iter()
+        .collect();
+        let fmt = (0..10).map(|_| vec![1]).collect();
+
+        let v = find_format_matches(fmt, counts).collect::<Vec<_>>();
+
+        assert_eq!(
+            v[0],
+            vec![
+                vec![(oc!(Card::BigJoker), 1)],
+                vec![(oc!(Card::BigJoker), 1)],
+                vec![(oc!(Card::BigJoker), 1)],
+                vec![(oc!(Card::BigJoker), 1)],
+                vec![(oc!(Card::SmallJoker), 1)],
+                vec![(oc!(Card::SmallJoker), 1)],
+                vec![(oc!(Card::SmallJoker), 1)],
+                vec![(oc!(Card::SmallJoker), 1)],
+                vec![(oc!(S_A), 1)],
+                vec![(oc!(S_A), 1)],
+            ]
+        );
+        assert_eq!(v.len(), 17865);
+    }
+}

--- a/mechanics/src/lib.rs
+++ b/mechanics/src/lib.rs
@@ -6,7 +6,9 @@
 
 pub mod bidding;
 pub mod deck;
+pub mod format_match;
 pub mod hands;
+pub mod multiset_iter;
 pub mod ordered_card;
 pub mod player;
 pub mod scoring;

--- a/mechanics/src/multiset_iter.rs
+++ b/mechanics/src/multiset_iter.rs
@@ -1,0 +1,180 @@
+use std::marker::PhantomData;
+
+/// Return all unique combinations of the provided keys with provided multiplicity of k
+/// k.
+pub fn multiset_k_combination_iter<A, K, F>(
+    keys: A,
+    multiplicity: F,
+    k: usize,
+) -> impl Iterator<Item = Vec<(K, usize)>> + Clone
+where
+    A: AsRef<[K]> + Clone,
+    K: Clone,
+    F: Fn(&K) -> usize + Clone,
+{
+    // Start out already-done if the required `k` is unsatisfiable.
+    let done = keys.as_ref().iter().map(&multiplicity).sum::<usize>() < k;
+    let mut current = vec![0; keys.as_ref().len()];
+
+    if !done {
+        __fill_to_k(k, |idx| multiplicity(&keys.as_ref()[idx]), &mut current);
+    }
+
+    MultisetKIter {
+        keys,
+        multiplicity,
+        current,
+        done,
+        _k: PhantomData,
+    }
+}
+
+#[derive(Clone)]
+struct MultisetKIter<A, K, F>
+where
+    A: AsRef<[K]> + Clone,
+    K: Clone,
+    F: Fn(&K) -> usize + Clone,
+{
+    /// The keys that we are computing the multiset over. Note that we will use these keys
+    /// irrespective of the actual keys in the provided `multiplicity`, so in practice we are using the
+    /// sub-multiset spanned by `keys`.
+    keys: A,
+    /// The multiplicity of each key in the multiset
+    multiplicity: F,
+    /// The current allocation of items in the multiset. Indices correspond to indices in `keys`;
+    /// elements are the count of values in `keys`. If !done, the sum of elements should always be
+    /// equal to `k`.
+    current: Vec<usize>,
+    /// Whether this iterator has been fully consumed.
+    done: bool,
+
+    _k: PhantomData<K>,
+}
+
+impl<A, K, F> Iterator for MultisetKIter<A, K, F>
+where
+    A: AsRef<[K]> + Clone,
+    K: Clone,
+    F: Fn(&K) -> usize + Clone,
+{
+    type Item = Vec<(K, usize)>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.done {
+            return None;
+        }
+
+        // 0. Compute the requisite output (to avoid off-by-one)
+        let output = Some(
+            self.current
+                .iter()
+                .enumerate()
+                .filter(|(_, ct)| **ct > 0)
+                .map(|(idx, ct)| (self.keys.as_ref()[idx].clone(), *ct))
+                .collect(),
+        );
+
+        // Attempt to increment the least-significant key-slots
+
+        // 1. Find the first nonzero value
+        let mut i = self.current.iter().position(|x| *x != 0).unwrap();
+
+        // 2. Set it to zero (stashing the previous value for later use)
+        let mut l = self.current[i];
+        self.current[i] = 0;
+
+        // 3. Increment and carry
+        loop {
+            i += 1;
+
+            // If we went past the last key, we're done!
+            if i >= self.current.len() {
+                self.done = true;
+                break;
+            }
+
+            if self.current[i] == (self.multiplicity)(&self.keys.as_ref()[i]) {
+                // Carry if we need to increment past the multiplicity of the key
+                l += self.current[i];
+                self.current[i] = 0;
+            } else {
+                l -= 1;
+                self.current[i] += 1;
+                break;
+            }
+        }
+
+        // 4. Fill in the lower key-slots
+        __fill_to_k(
+            l,
+            |idx| (self.multiplicity)(&self.keys.as_ref()[idx]),
+            &mut self.current,
+        );
+
+        output
+    }
+}
+
+/// Fill `current` from the least-significant key-slot with `k` items.
+fn __fill_to_k(k: usize, multiplicity: impl Fn(usize) -> usize, state: &mut [usize]) {
+    let mut i = 0;
+    let mut n = k;
+    loop {
+        let m = multiplicity(i);
+        if n <= m {
+            debug_assert_eq!(state[i], 0);
+            state[i] = n;
+            break;
+        }
+
+        state[i] = m;
+        n -= m;
+        i += 1;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use super::multiset_k_combination_iter;
+
+    #[test]
+    fn test_multiset_iter() {
+        let multiset = [('a', 10), ('b', 4), ('c', 3)]
+            .into_iter()
+            .collect::<BTreeMap<_, _>>();
+        let res = multiset_k_combination_iter(
+            &multiset.keys().rev().collect::<Vec<_>>(),
+            |k| multiset[*k],
+            6,
+        )
+        .map(|v| v.into_iter().map(|(c, ct)| (*c, ct)).collect::<Vec<_>>())
+        .collect::<Vec<_>>();
+        assert_eq!(
+            res,
+            vec![
+                vec![('c', 3), ('b', 3)],
+                vec![('c', 2), ('b', 4)],
+                vec![('c', 3), ('b', 2), ('a', 1)],
+                vec![('c', 2), ('b', 3), ('a', 1)],
+                vec![('c', 1), ('b', 4), ('a', 1)],
+                vec![('c', 3), ('b', 1), ('a', 2)],
+                vec![('c', 2), ('b', 2), ('a', 2)],
+                vec![('c', 1), ('b', 3), ('a', 2)],
+                vec![('b', 4), ('a', 2)],
+                vec![('c', 3), ('a', 3)],
+                vec![('c', 2), ('b', 1), ('a', 3)],
+                vec![('c', 1), ('b', 2), ('a', 3)],
+                vec![('b', 3), ('a', 3)],
+                vec![('c', 2), ('a', 4)],
+                vec![('c', 1), ('b', 1), ('a', 4)],
+                vec![('b', 2), ('a', 4)],
+                vec![('c', 1), ('a', 5)],
+                vec![('b', 1), ('a', 5)],
+                vec![('a', 6)],
+            ]
+        )
+    }
+}

--- a/mechanics/src/trick.rs
+++ b/mechanics/src/trick.rs
@@ -7,7 +7,7 @@ use thiserror::Error;
 
 use crate::hands::{HandError, Hands};
 use crate::ordered_card::{
-    attempt_format_match, subsequent_decomposition_ordering, AdjacentTupleSizes, MatchingCards,
+    subsequent_decomposition_ordering, AdjacentTupleSizes, MatchingCards, MatchingCardsRef,
     OrderedCard,
 };
 use crate::types::{Card, EffectiveSuit, PlayerID, Trump};
@@ -273,24 +273,24 @@ impl TrickFormat {
             for requirement in self.decomposition(trick_draw_policy) {
                 // If it's a match, we're good!
                 let play_matches = UnitLike::check_play(
-                    self.trump,
-                    proposed.iter().copied(),
+                    OrderedCard::make_map(proposed.iter().copied(), self.trump),
                     requirement.iter().cloned(),
                     TrickDrawPolicy::NoProtections,
                 )
-                .0;
+                .next()
+                .is_some();
 
                 if play_matches {
                     return true;
                 }
                 // Otherwise, if it could match in the player's hand, it's not OK.
                 let hand_can_play = UnitLike::check_play(
-                    self.trump,
-                    available_cards.iter().copied(),
+                    OrderedCard::make_map(available_cards.iter().copied(), self.trump),
                     requirement.iter().cloned(),
                     trick_draw_policy,
                 )
-                .0;
+                .next()
+                .is_some();
                 if hand_can_play {
                     return false;
                 }
@@ -302,7 +302,7 @@ impl TrickFormat {
         }
     }
 
-    pub fn matches(&self, cards: &'_ [Card]) -> Result<Units, TrickError> {
+    pub fn matches(&self, cards: &[Card]) -> Result<impl Iterator<Item = Units> + '_, TrickError> {
         let suit = self.trump.effective_suit(cards[0]);
         for card in cards {
             if self.trump.effective_suit(*card) != suit {
@@ -318,45 +318,32 @@ impl TrickFormat {
             return Err(TrickError::NonMatchingPlay);
         }
 
-        let (found, matches) = UnitLike::check_play(
-            self.trump,
-            cards.iter().copied(),
+        let mut matches = UnitLike::check_play(
+            OrderedCard::make_map(cards.iter().copied(), self.trump),
             self.units.iter().map(UnitLike::from),
             TrickDrawPolicy::NoProtections,
-        );
+        )
+        .peekable();
 
-        let found_units: Units = matches
-            .into_iter()
-            .map(|m| {
-                if m.len() == 1 {
-                    let (card, count) = m[0];
-                    TrickUnit::Repeated { count, card }
-                } else {
-                    let min = m.iter().map(|(_, count)| count).min().unwrap();
-                    let max = m.iter().map(|(_, count)| count).max().unwrap();
-                    debug_assert_eq!(min, max);
-                    TrickUnit::Tractor {
-                        count: *min,
-                        members: m.iter().map(|(card, _)| *card).collect(),
-                    }
-                }
-            })
-            .collect();
-
-        if found {
-            debug_assert_eq!(
-                self.units
-                    .iter()
-                    .map(UnitLike::from)
-                    .collect::<HashSet<_>>(),
-                found_units
-                    .iter()
-                    .map(UnitLike::from)
-                    .collect::<HashSet<_>>()
-            );
-            Ok(found_units)
-        } else {
+        if matches.peek().is_none() {
             Err(TrickError::NonMatchingPlay)
+        } else {
+            Ok(matches.map(|m| m.into_iter().map(Self::match_to_unit).collect()))
+        }
+    }
+
+    fn match_to_unit(m: Vec<(OrderedCard, usize)>) -> TrickUnit {
+        if m.len() == 1 {
+            let (card, count) = m[0];
+            TrickUnit::Repeated { count, card }
+        } else {
+            let min = m.iter().map(|(_, count)| count).min().unwrap();
+            let max = m.iter().map(|(_, count)| count).max().unwrap();
+            debug_assert_eq!(min, max);
+            TrickUnit::Tractor {
+                count: *min,
+                members: m.iter().map(|(card, _)| *card).collect(),
+            }
         }
     }
 
@@ -667,7 +654,8 @@ impl Trick {
         self.played_card_mappings.push(
             self.trick_format
                 .as_ref()
-                .and_then(|tf| tf.matches(&cards).ok()),
+                .and_then(|tf| tf.matches(&cards).ok())
+                .and_then(|mut f| f.next()),
         );
 
         self.played_cards.push(PlayedCards {
@@ -749,6 +737,51 @@ impl Trick {
         }
     }
 
+    fn _defeats(m: &Units, winner: &Units, throw_eval_policy: ThrowEvaluationPolicy) -> bool {
+        match throw_eval_policy {
+            ThrowEvaluationPolicy::All => m
+                .iter()
+                .zip(winner.iter())
+                .all(|(n, w)| n.first_card().cmp_effective(w.first_card()) == Ordering::Greater),
+            ThrowEvaluationPolicy::Highest => {
+                let n_max = m
+                    .iter()
+                    .map(|u| u.last_card())
+                    .max()
+                    .expect("trick format cannot be empty");
+                let w_max = winner
+                    .iter()
+                    .map(|u| u.last_card())
+                    .max()
+                    .expect("trick format cannot be empty");
+                n_max.cmp_effective(w_max) == Ordering::Greater
+            }
+            ThrowEvaluationPolicy::TrickUnitLength => {
+                // Don't worry about single cards if this is a throw with at
+                // least one unit that is longer than a single card, but do
+                // evaluate them if it isn't!
+                let skip_single_cards = m.len() > 1 && m.iter().any(|n| n.size() > 1);
+
+                let mut comparisons = m
+                    .iter()
+                    .zip(winner.iter())
+                    .filter(|(n, _)| !skip_single_cards || n.size() > 1)
+                    .map(|(n, w)| (n.size(), n.first_card().cmp_effective(w.first_card())))
+                    .collect::<Vec<_>>();
+                // Compare by size first, then try to skip equal-comparisons.
+                comparisons.sort_by_key(|(s, c)| (-(*s as isize), *c == Ordering::Equal));
+                let mut iter = comparisons.into_iter().map(|(_, c)| c);
+                loop {
+                    match iter.next() {
+                        Some(Ordering::Equal) => {}
+                        Some(Ordering::Greater) => break true,
+                        Some(Ordering::Less) | None => break false,
+                    }
+                }
+            }
+        }
+    }
+
     fn winner(
         trick_format: Option<&'_ TrickFormat>,
         played_cards: &'_ [PlayedCards],
@@ -759,57 +792,9 @@ impl Trick {
                 let mut winner = (0, tf.units.to_vec());
 
                 for (idx, pc) in played_cards.iter().enumerate().skip(1) {
-                    if let Ok(m) = tf.matches(&pc.cards) {
-                        let greater = match throw_eval_policy {
-                            ThrowEvaluationPolicy::All => {
-                                m.iter().zip(winner.1.iter()).all(|(n, w)| {
-                                    n.first_card().cmp_effective(w.first_card())
-                                        == Ordering::Greater
-                                })
-                            }
-                            ThrowEvaluationPolicy::Highest => {
-                                let n_max = m
-                                    .iter()
-                                    .map(|u| u.last_card())
-                                    .max()
-                                    .expect("trick format cannot be empty");
-                                let w_max = winner
-                                    .1
-                                    .iter()
-                                    .map(|u| u.last_card())
-                                    .max()
-                                    .expect("trick format cannot be empty");
-                                n_max.cmp_effective(w_max) == Ordering::Greater
-                            }
-                            ThrowEvaluationPolicy::TrickUnitLength => {
-                                // Don't worry about single cards if this is a throw with at
-                                // least one unit that is longer than a single card, but do
-                                // evaluate them if it isn't!
-                                let skip_single_cards =
-                                    m.len() > 1 && m.iter().any(|n| n.size() > 1);
-
-                                let mut comparisons = m
-                                    .iter()
-                                    .zip(winner.1.iter())
-                                    .filter(|(n, _)| !skip_single_cards || n.size() > 1)
-                                    .map(|(n, w)| {
-                                        (n.size(), n.first_card().cmp_effective(w.first_card()))
-                                    })
-                                    .collect::<Vec<_>>();
-                                // Compare by size first, then try to skip equal-comparisons.
-                                comparisons
-                                    .sort_by_key(|(s, c)| (-(*s as isize), *c == Ordering::Equal));
-                                let mut iter = comparisons.into_iter().map(|(_, c)| c);
-                                loop {
-                                    match iter.next() {
-                                        Some(Ordering::Equal) => {}
-                                        Some(Ordering::Greater) => break true,
-                                        Some(Ordering::Less) | None => break false,
-                                    }
-                                }
-                            }
-                        };
-                        if greater {
+                    if let Ok(mut mm) = tf.matches(&pc.cards) {
+                        let greater = mm.find(|m| Self::_defeats(m, &winner.1, throw_eval_policy));
+                        if let Some(m) = greater {
                             winner = (idx, m);
                         }
                     }
@@ -924,28 +909,26 @@ impl UnitLike {
     }
 
     pub fn check_play(
-        trump: Trump,
-        iter: impl IntoIterator<Item = Card>,
-        units: impl Iterator<Item = UnitLike> + Clone,
+        counts: BTreeMap<OrderedCard, usize>,
+        units: impl Iterator<Item = UnitLike>,
         trick_draw_policy: TrickDrawPolicy,
-    ) -> (bool, Vec<MatchingCards>) {
-        let mut counts = BTreeMap::new();
-        for card in iter.into_iter() {
-            let card = OrderedCard { card, trump };
-            *counts.entry(card).or_insert(0) += 1;
-        }
-        attempt_format_match(
-            &mut counts,
-            units.map(|u| u.adjacent_tuples),
-            |counts, matching| match trick_draw_policy {
-                TrickDrawPolicy::NoFormatBasedDraw
-                | TrickDrawPolicy::NoProtections
-                | TrickDrawPolicy::OnlyDrawTractorOnTractor => true,
-                TrickDrawPolicy::LongerTuplesProtected => !matching
-                    .iter()
-                    .any(|(card, count)| counts.get(card).copied().unwrap_or_default() > *count),
-            },
-        )
+    ) -> impl Iterator<Item = Vec<MatchingCards>> {
+        let counts_ = counts.clone();
+        let filter_func = move |matching: &MatchingCardsRef| match trick_draw_policy {
+            TrickDrawPolicy::NoFormatBasedDraw
+            | TrickDrawPolicy::NoProtections
+            | TrickDrawPolicy::OnlyDrawTractorOnTractor => true,
+            TrickDrawPolicy::LongerTuplesProtected => !matching
+                .iter()
+                .any(|(card, count)| counts_.get(card).copied().unwrap_or_default() > *count),
+        };
+        let units = units
+            .into_iter()
+            .map(|u| u.adjacent_tuples)
+            .collect::<Vec<_>>();
+
+        crate::format_match::find_format_matches(units, counts)
+            .filter(move |m| m.iter().all(|mm| filter_func(mm)))
     }
 }
 
@@ -1140,14 +1123,7 @@ mod tests {
     use std::iter::FromIterator;
 
     use crate::hands::Hands;
-    use crate::types::{
-        cards::{
-            C_10, C_4, C_5, C_6, C_7, C_8, C_A, C_K, C_Q, D_4, D_A, D_K, H_10, H_2, H_3, H_4, H_5,
-            H_7, H_8, H_9, H_A, H_K, S_10, S_2, S_3, S_4, S_5, S_6, S_7, S_8, S_9, S_A, S_J, S_K,
-            S_Q,
-        },
-        Card, EffectiveSuit, Number, PlayerID, Suit, Trump,
-    };
+    use crate::types::{cards::*, Card, EffectiveSuit, Number, PlayerID, Suit, Trump};
 
     use super::{
         OrderedCard, PlayCards, ThrowEvaluationPolicy, TractorRequirements, Trick, TrickDrawPolicy,
@@ -1243,8 +1219,8 @@ mod tests {
                     HashSet::from_iter(vec![$(vec![$(vec![$($y),+]),+]),+])
                 );
                 for u in units {
-                    let (found, play) = UnitLike::check_play(TRUMP, cards.iter().copied(), u.iter().map(UnitLike::from), TrickDrawPolicy::NoProtections);
-                    assert!(found);
+                    let mut iter = UnitLike::check_play(OrderedCard::make_map(cards.iter().copied(), TRUMP), u.iter().map(UnitLike::from), TrickDrawPolicy::NoProtections);
+                    let play = iter.next().unwrap();
                     assert_eq!(
                         u.iter().map(UnitLike::from).collect::<HashSet<_>>(),
                         play.iter().map(UnitLike::from).collect::<HashSet<_>>()
@@ -2276,5 +2252,48 @@ mod tests {
 
         let TrickEnded { winner, .. } = f(ThrowEvaluationPolicy::TrickUnitLength);
         assert_eq!(winner, P3);
+    }
+
+    #[test]
+    fn test_trick_format_multi_parse() {
+        let f = |tep| {
+            let trump = Trump::Standard {
+                number: Number::Two,
+                suit: Suit::Clubs,
+            };
+            let mut hands = Hands::new(vec![P1, P2, P3, P4]);
+            hands.set_trump(trump);
+            hands.add(P1, vec![D_8, D_8, D_J, D_Q]).unwrap();
+            hands.add(P2, vec![C_5, C_5, C_A, S_2]).unwrap();
+            hands.add(P3, vec![S_3, S_3, C_7, C_8]).unwrap();
+            hands.add(P4, vec![C_6, C_6, C_2, C_2]).unwrap();
+
+            let mut trick = Trick::new(trump, vec![P1, P2, P3, P4]);
+            trick
+                .play_cards(pc!(P1, &mut hands, &[D_8, D_8, D_J, D_Q], tep))
+                .unwrap();
+            trick
+                .play_cards(pc!(P2, &mut hands, &[C_5, C_5, C_A, S_2], tep))
+                .unwrap();
+            trick
+                .play_cards(pc!(P3, &mut hands, &[S_3, S_3, C_7, C_8], tep))
+                .unwrap();
+
+            // test the case where there's an ambiguous trick-format parse (2/1/1, where the 2 can
+            // either be a pair of twos or a pair of sixes, and only one of them will win the
+            // trick.
+            trick
+                .play_cards(pc!(P4, &mut hands, &[C_6, C_6, C_2, C_2], tep))
+                .unwrap();
+            trick.complete().unwrap()
+        };
+        let TrickEnded { winner, .. } = f(ThrowEvaluationPolicy::All);
+        assert_eq!(winner, P4);
+
+        let TrickEnded { winner, .. } = f(ThrowEvaluationPolicy::Highest);
+        assert_eq!(winner, P4);
+
+        let TrickEnded { winner, .. } = f(ThrowEvaluationPolicy::TrickUnitLength);
+        assert_eq!(winner, P4);
     }
 }


### PR DESCRIPTION
1. Implement a more efficient matching algorithm for finding possible plays
2. Only run the expensive computation for possible plays when requested (e.g. when the user accesses the help menu)
3. Add a button to suggest a valid following play (does not work if the user doesn't have enough cards in the appropriate suit)

Fixes #411