### PR TITLE
Implement Game Visibility And Add Public Rooms Panel on Front Page

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -132,7 +132,8 @@ async fn main() -> Result<(), anyhow::Error> {
         .route(
             "/rules",
             get(|| async { Redirect::permanent("/rules.html") }),
-        );
+        )
+        .route("/public_games.json", get(state_dump::public_games));
 
     #[cfg(feature = "dynamic")]
     let app = app.fallback_service(

--- a/backend/src/state_dump.rs
+++ b/backend/src/state_dump.rs
@@ -29,7 +29,7 @@ impl InMemoryStats {
     }
 }
 
-#[derive(Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct PublicGameInfo {
     name: String,
     num_players: usize,
@@ -208,6 +208,6 @@ pub async fn public_games(
         }
     }
 
-    public_games.sort();
+    public_games.sort_by_key( |p| (-(p.num_players as isize), p.name.clone()));
     Ok(Json(public_games))
 }

--- a/backend/src/state_dump.rs
+++ b/backend/src/state_dump.rs
@@ -199,15 +199,15 @@ pub async fn public_games(
         if let Ok(versioned_game) = backend_storage.clone().get(room_name.clone()).await {
             if let GameVisibility::Public = versioned_game.game.game_visibility() {
                 if let Ok(name) = String::from_utf8(room_name.clone()) {
-                    public_games.push(PublicGameInfo{
+                    public_games.push(PublicGameInfo {
                         name,
-                        num_players: versioned_game.game.players().len()
+                        num_players: versioned_game.game.players().len(),
                     });
                 }
             }
         }
     }
 
-    public_games.sort_by_key( |p| (-(p.num_players as isize), p.name.clone()));
+    public_games.sort_by_key(|p| (-(p.num_players as isize), p.name.clone()));
     Ok(Json(public_games))
 }

--- a/core/src/interactive.rs
+++ b/core/src/interactive.rs
@@ -15,11 +15,7 @@ use shengji_mechanics::types::{Card, PlayerID, Rank};
 
 use crate::game_state::{initialize_phase::InitializePhase, GameState};
 use crate::message::MessageVariant;
-use crate::settings::{
-    AdvancementPolicy, FirstLandlordSelectionPolicy, FriendSelection, FriendSelectionPolicy,
-    GameModeSettings, GameShadowingPolicy, GameStartPolicy, KittyBidPolicy, KittyPenalty,
-    KittyTheftPolicy, MultipleJoinPolicy, PlayTakebackPolicy, PropagatedState, ThrowPenalty,
-};
+use crate::settings::{AdvancementPolicy, FirstLandlordSelectionPolicy, FriendSelection, FriendSelectionPolicy, GameModeSettings, GameShadowingPolicy, GameStartPolicy, GameVisibility, KittyBidPolicy, KittyPenalty, KittyTheftPolicy, MultipleJoinPolicy, PlayTakebackPolicy, PropagatedState, ThrowPenalty};
 
 pub struct InteractiveGame {
     state: GameState,
@@ -219,6 +215,10 @@ impl InteractiveGame {
             (Action::SetGameMode(game_mode), GameState::Initialize(ref mut state)) => {
                 info!(logger, "Setting game mode"; "game_mode" => game_mode.variant());
                 state.set_game_mode(game_mode)?
+            }
+            (Action::SetGameVisibility(visibility), GameState::Initialize(ref mut state)) => {
+                info!(logger, "Setting game visibility"; "visibility" => visibility);
+                state.set_game_visibility(visibility)?
             }
             (Action::SetKittyPenalty(kitty_penalty), GameState::Initialize(ref mut state)) => {
                 info!(logger, "Setting kitty penalty"; "penalty" => kitty_penalty);
@@ -446,6 +446,7 @@ pub enum Action {
     SetShouldRevealKittyAtEndOfGame(bool),
     SetHideThrowHaltingPlayer(bool),
     SetTractorRequirements(TractorRequirements),
+    SetGameVisibility(GameVisibility),
     StartGame,
     DrawCard,
     RevealCard,

--- a/core/src/interactive.rs
+++ b/core/src/interactive.rs
@@ -15,8 +15,12 @@ use shengji_mechanics::types::{Card, PlayerID, Rank};
 
 use crate::game_state::{initialize_phase::InitializePhase, GameState};
 use crate::message::MessageVariant;
-use crate::settings::{AdvancementPolicy, FirstLandlordSelectionPolicy, FriendSelection, FriendSelectionPolicy, GameModeSettings, GameShadowingPolicy, GameStartPolicy, GameVisibility, KittyBidPolicy, KittyPenalty, KittyTheftPolicy, MultipleJoinPolicy, PlayTakebackPolicy, PropagatedState, ThrowPenalty};
-
+use crate::settings::{
+    AdvancementPolicy, FirstLandlordSelectionPolicy, FriendSelection, FriendSelectionPolicy,
+    GameModeSettings, GameShadowingPolicy, GameStartPolicy, GameVisibility, KittyBidPolicy,
+    KittyPenalty, KittyTheftPolicy, MultipleJoinPolicy, PlayTakebackPolicy, PropagatedState,
+    ThrowPenalty,
+};
 pub struct InteractiveGame {
     state: GameState,
 }

--- a/core/src/message.rs
+++ b/core/src/message.rs
@@ -13,11 +13,7 @@ use shengji_mechanics::trick::{ThrowEvaluationPolicy, TractorRequirements, Trick
 use shengji_mechanics::types::{Card, PlayerID, Rank};
 
 use crate::game_state::play_phase::PlayerGameFinishedResult;
-use crate::settings::{
-    AdvancementPolicy, FirstLandlordSelectionPolicy, FriendSelectionPolicy, GameModeSettings,
-    GameShadowingPolicy, GameStartPolicy, KittyBidPolicy, KittyPenalty, KittyTheftPolicy,
-    MultipleJoinPolicy, PlayTakebackPolicy, ThrowPenalty,
-};
+use crate::settings::{AdvancementPolicy, FirstLandlordSelectionPolicy, FriendSelectionPolicy, GameModeSettings, GameShadowingPolicy, GameStartPolicy, GameVisibility, KittyBidPolicy, KittyPenalty, KittyTheftPolicy, MultipleJoinPolicy, PlayTakebackPolicy, ThrowPenalty};
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(tag = "type")]
@@ -101,6 +97,9 @@ pub enum MessageVariant {
     },
     KittyTheftPolicySet {
         policy: KittyTheftPolicy,
+    },
+    GameVisibilitySet {
+        visibility: GameVisibility,
     },
     TookBackPlay,
     TookBackBid,
@@ -370,6 +369,8 @@ impl MessageVariant {
             HideThrowHaltingPlayer { set: false } => format!("{} un-hid the player who prevents throws", n?),
             TractorRequirementsChanged { tractor_requirements } =>
                 format!("{} required tractors to be at least {} cards wide by {} tuples long", n?, tractor_requirements.min_count, tractor_requirements.min_length),
+            GameVisibilitySet { visibility: GameVisibility::Public} => format!("{} listed the game publicly", n?),
+            GameVisibilitySet { visibility: GameVisibility::Unlisted} => format!("{} unlisted the game", n?),
         })
     }
 }

--- a/core/src/message.rs
+++ b/core/src/message.rs
@@ -13,8 +13,11 @@ use shengji_mechanics::trick::{ThrowEvaluationPolicy, TractorRequirements, Trick
 use shengji_mechanics::types::{Card, PlayerID, Rank};
 
 use crate::game_state::play_phase::PlayerGameFinishedResult;
-use crate::settings::{AdvancementPolicy, FirstLandlordSelectionPolicy, FriendSelectionPolicy, GameModeSettings, GameShadowingPolicy, GameStartPolicy, GameVisibility, KittyBidPolicy, KittyPenalty, KittyTheftPolicy, MultipleJoinPolicy, PlayTakebackPolicy, ThrowPenalty};
-
+use crate::settings::{
+    AdvancementPolicy, FirstLandlordSelectionPolicy, FriendSelectionPolicy, GameModeSettings,
+    GameShadowingPolicy, GameStartPolicy, GameVisibility, KittyBidPolicy, KittyPenalty,
+    KittyTheftPolicy, MultipleJoinPolicy, PlayTakebackPolicy, ThrowPenalty,
+};
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(tag = "type")]
 pub enum MessageVariant {

--- a/core/src/settings.rs
+++ b/core/src/settings.rs
@@ -816,7 +816,9 @@ impl PropagatedState {
     ) -> Result<Vec<MessageVariant>, Error> {
         if game_visibility != self.game_visibility {
             self.game_visibility = game_visibility;
-            Ok(vec![MessageVariant::GameVisibilitySet { visibility: game_visibility }])
+            Ok(vec![MessageVariant::GameVisibilitySet {
+                visibility: game_visibility,
+            }])
         } else {
             Ok(vec![])
         }

--- a/core/src/settings.rs
+++ b/core/src/settings.rs
@@ -247,6 +247,20 @@ impl Default for GameStartPolicy {
 shengji_mechanics::impl_slog_value!(GameStartPolicy);
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub enum GameVisibility {
+    Public,
+    Unlisted,
+}
+
+impl Default for GameVisibility {
+    fn default() -> Self {
+        GameVisibility::Unlisted
+    }
+}
+
+shengji_mechanics::impl_slog_value!(GameVisibility);
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct MaxRank(Rank);
 shengji_mechanics::impl_slog_value!(MaxRank);
 impl Default for MaxRank {
@@ -334,6 +348,8 @@ pub struct PropagatedState {
     pub(crate) tractor_requirements: TractorRequirements,
     #[serde(default)]
     pub(crate) max_rank: MaxRank,
+    #[serde(default)]
+    pub(crate) game_visibility: GameVisibility,
 }
 
 impl PropagatedState {
@@ -355,6 +371,10 @@ impl PropagatedState {
 
     pub fn num_decks(&self) -> usize {
         self.num_decks.unwrap_or(self.players.len() / 2)
+    }
+
+    pub fn game_visibility(&self) -> GameVisibility {
+        self.game_visibility
     }
 
     pub fn decks(&self) -> Result<Vec<Deck>, Error> {
@@ -785,6 +805,18 @@ impl PropagatedState {
         if policy != self.kitty_theft_policy {
             self.kitty_theft_policy = policy;
             Ok(vec![MessageVariant::KittyTheftPolicySet { policy }])
+        } else {
+            Ok(vec![])
+        }
+    }
+
+    pub fn set_game_visibility(
+        &mut self,
+        game_visibility: GameVisibility,
+    ) -> Result<Vec<MessageVariant>, Error> {
+        if game_visibility != self.game_visibility {
+            self.game_visibility = game_visibility;
+            Ok(vec![MessageVariant::GameVisibilitySet { visibility: game_visibility }])
         } else {
             Ok(vec![])
         }

--- a/frontend/src/Credits.tsx
+++ b/frontend/src/Credits.tsx
@@ -9,7 +9,7 @@ const contentStyle: React.CSSProperties = {
   transform: "translate(-50%, -50%)",
 };
 
-const changeLogVersion: number = 21;
+const changeLogVersion: number = 22;
 
 const ChangeLog = (): JSX.Element => {
   const [modalOpen, setModalOpen] = React.useState<boolean>(false);
@@ -59,6 +59,13 @@ const ChangeLog = (): JSX.Element => {
           you&apos;re in the game.
         </p>
         <h2>Change Log</h2>
+        <p>2/24/2023:</p>
+        <ul>
+          <li>
+            Added the ability to list a room publicly for others to join (thanks
+            jimmyfang94!)
+          </li>
+        </ul>
         <p>1/18/2023:</p>
         <ul>
           <li>Fixed performance issue when playing tricks with many cards</li>

--- a/frontend/src/Initialize.tsx
+++ b/frontend/src/Initialize.tsx
@@ -1057,6 +1057,13 @@ const Initialize = (props: IProps): JSX.Element => {
               },
             });
             break;
+          case "game_visibility":
+            send({
+              Action: {
+                SetGameVisibility: value,
+              },
+            });
+            break;
         }
       }
     }

--- a/frontend/src/Initialize.tsx
+++ b/frontend/src/Initialize.tsx
@@ -731,6 +731,7 @@ const Initialize = (props: IProps): JSX.Element => {
   const setGameShadowingPolicy = onSelectString("SetGameShadowingPolicy");
   const setGameStartPolicy = onSelectString("SetGameStartPolicy");
   const setBidTakebackPolicy = onSelectString("SetBidTakebackPolicy");
+  const setGameVisibility = onSelectString("SetGameVisibility");
 
   const setShouldRevealKittyAtEndOfGame = (
     evt: React.ChangeEvent<HTMLSelectElement>
@@ -1291,6 +1292,18 @@ const Initialize = (props: IProps): JSX.Element => {
           setPlayTakebackPolicy={setPlayTakebackPolicy}
           setBidTakebackPolicy={setBidTakebackPolicy}
         />
+        <div>
+          <label>
+            Game Visibility{" "}
+            <select
+              value={props.state.propagated.game_visibility}
+              onChange={setGameVisibility}
+            >
+              <option value={"Unlisted"}>Unlisted</option>
+              <option value={"Public"}>Public</option>
+            </select>
+          </label>
+        </div>
         <h3>Continuation settings</h3>
         <LandlordSelector
           players={props.state.propagated.players}

--- a/frontend/src/JoinRoom.tsx
+++ b/frontend/src/JoinRoom.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { WebsocketContext } from "./WebsocketProvider";
 import { TimerContext } from "./TimerProvider";
 import LabeledPlay from "./LabeledPlay";
+import PublicRoomsPane from "./PublicRoomsPane";
 
 interface IProps {
   name: string;
@@ -136,6 +137,7 @@ const JoinRoom = (props: IProps): JSX.Element => {
           to you.
         </p>
       </div>
+      <PublicRoomsPane />
     </div>
   );
 };

--- a/frontend/src/JoinRoom.tsx
+++ b/frontend/src/JoinRoom.tsx
@@ -137,7 +137,7 @@ const JoinRoom = (props: IProps): JSX.Element => {
           to you.
         </p>
       </div>
-      <PublicRoomsPane />
+      <PublicRoomsPane setRoomName={props.setRoomName} />
     </div>
   );
 };

--- a/frontend/src/PublicRoomsPane.tsx
+++ b/frontend/src/PublicRoomsPane.tsx
@@ -10,7 +10,7 @@ const LabelCell = styled.div`
   display: table-cell;
   padding-right: 2em;
   font-weight: bold;
-  width: 125px;
+  width: 200px;
 `;
 const Cell = styled.div`
   display: table-cell;
@@ -30,7 +30,9 @@ const PublicRoomRow = ({
   return (
     <Row>
       <Cell>
-        <button onClick={(e) => setRoomName(roomName, e)}>{roomName}</button>
+        <button onClick={(e) => setRoomName(roomName, e)} className="normal">
+          {roomName}
+        </button>
       </Cell>
       <Cell>{numPlayers}</Cell>
     </Row>
@@ -77,10 +79,12 @@ const PublicRoomsPane = (props: IProps): JSX.Element => {
           <LabelCell>Room Name</LabelCell>
           <LabelCell>Players</LabelCell>
           <LabelCell>
-            <button onClick={loadPublicRooms}> Refresh </button>
+            <button onClick={loadPublicRooms} className="normal">
+              Refresh
+            </button>
           </LabelCell>
         </Row>
-        {publicRooms.length === 0 && <div>No rooms available</div>}
+        {publicRooms.length === 0 && <Cell>No public rooms available</Cell>}
         {publicRooms.map((roomInfo) => {
           return (
             <PublicRoomRow

--- a/frontend/src/PublicRoomsPane.tsx
+++ b/frontend/src/PublicRoomsPane.tsx
@@ -1,0 +1,123 @@
+import * as React from "react";
+import { useEffect, useState } from "react";
+import styled from "styled-components";
+
+const Row = styled.div`
+  display: table-row;
+  line-height: 23px;
+`;
+const LabelCell = styled.div`
+  display: table-cell;
+  padding-right: 2em;
+  font-weight: bold;
+  width: 125px;
+`;
+const Cell = styled.div`
+  display: table-cell;
+`;
+
+interface RowIProps {
+  roomName: string;
+  numPlayers: number;
+}
+
+const PublicRoomRow = ({ roomName, numPlayers }: RowIProps): JSX.Element => {
+  return (
+    <Row>
+      <Cell>{roomName}</Cell>
+      <Cell>{numPlayers}</Cell>
+    </Row>
+  );
+};
+
+const PublicRoomsPane = (): JSX.Element => {
+  const [publicRooms, setPublicRooms] = useState([]);
+
+  useEffect(() => {
+    loadPublicRooms();
+  }, []);
+  const loadPublicRooms = (): void => {
+    try {
+      const fetchAsync = async (): Promise<void> => {
+        const fetchResult = await fetch("public_games.json");
+        const resultJSON = await fetchResult.json();
+        const resultArray = Object.entries(resultJSON);
+
+        // sort by number of players first, then name second
+        resultArray.sort((a: [string, any], b: [string, any]) => {
+          const aKey = a[0];
+          const aValue = a[1];
+          const bKey = b[0];
+          const bValue = b[1];
+
+          if (
+            aValue.Initialize === undefined ||
+            aValue.Initialize.propagated === undefined ||
+            aValue.Initialize.propagated.players === undefined ||
+            bValue.Initialize === undefined ||
+            bValue.Initialize.propagated === undefined ||
+            bValue.Initialize.propagated.players === undefined
+          ) {
+            throw new Error(
+              `failed validation while sorting public rooms between ${aKey} ${bKey}`
+            );
+          }
+
+          const playerDiff =
+            bValue.Initialize.propagated.players.length -
+            aValue.Initialize.propagated.players.length;
+
+          if (playerDiff !== 0) {
+            return playerDiff;
+          }
+
+          return aKey.localeCompare(bKey);
+        });
+        setPublicRooms(resultArray);
+      };
+
+      fetchAsync().catch((e) => {
+        console.error(e);
+      });
+    } catch (err) {
+      console.log(err);
+    }
+  };
+
+  return (
+    <div className="">
+      <h3>Public Rooms</h3>
+      <div>
+        <p>
+          The games listed below are open to the public. Join them to find new
+          friends to play with!
+        </p>
+        <p>
+          Copy the room name into the input above, fill out your player name,
+          and click join to enter the room.
+        </p>
+      </div>
+      <div style={{ display: "table", borderSpacing: 10 }}>
+        <Row>
+          <LabelCell>Room Name</LabelCell>
+          <LabelCell>Players</LabelCell>
+          <LabelCell>
+            <button onClick={loadPublicRooms}> Refresh </button>
+          </LabelCell>
+        </Row>
+        {publicRooms.length === 0 && <div>No rooms available</div>}
+        {publicRooms.map(([key, value]) => {
+          return (
+            <PublicRoomRow
+              key={key}
+              roomName={key}
+              numPlayers={value.Initialize.propagated.players.length}
+            />
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default PublicRoomsPane;

--- a/frontend/src/PublicRoomsPane.tsx
+++ b/frontend/src/PublicRoomsPane.tsx
@@ -19,18 +19,29 @@ const Cell = styled.div`
 interface RowIProps {
   roomName: string;
   numPlayers: number;
+  setRoomName: (name: string, e: React.MouseEvent) => void;
 }
 
-const PublicRoomRow = ({ roomName, numPlayers }: RowIProps): JSX.Element => {
+const PublicRoomRow = ({
+  roomName,
+  numPlayers,
+  setRoomName,
+}: RowIProps): JSX.Element => {
   return (
     <Row>
-      <Cell>{roomName}</Cell>
+      <Cell>
+        <button onClick={(e) => setRoomName(roomName, e)}>{roomName}</button>
+      </Cell>
       <Cell>{numPlayers}</Cell>
     </Row>
   );
 };
 
-const PublicRoomsPane = (): JSX.Element => {
+interface IProps {
+  setRoomName: (name: string) => void;
+}
+
+const PublicRoomsPane = (props: IProps): JSX.Element => {
   const [publicRooms, setPublicRooms] = useState([]);
 
   useEffect(() => {
@@ -60,10 +71,6 @@ const PublicRoomsPane = (): JSX.Element => {
           The games listed below are open to the public. Join them to find new
           friends to play with!
         </p>
-        <p>
-          Copy the room name into the input above, fill out your player name,
-          and click join to enter the room.
-        </p>
       </div>
       <div style={{ display: "table", borderSpacing: 10 }}>
         <Row>
@@ -80,6 +87,7 @@ const PublicRoomsPane = (): JSX.Element => {
               key={roomInfo.name}
               roomName={roomInfo.name}
               numPlayers={roomInfo.num_players}
+              setRoomName={props.setRoomName}
             />
           );
         })}

--- a/frontend/src/PublicRoomsPane.tsx
+++ b/frontend/src/PublicRoomsPane.tsx
@@ -41,39 +41,7 @@ const PublicRoomsPane = (): JSX.Element => {
       const fetchAsync = async (): Promise<void> => {
         const fetchResult = await fetch("public_games.json");
         const resultJSON = await fetchResult.json();
-        const resultArray = Object.entries(resultJSON);
-
-        // sort by number of players first, then name second
-        resultArray.sort((a: [string, any], b: [string, any]) => {
-          const aKey = a[0];
-          const aValue = a[1];
-          const bKey = b[0];
-          const bValue = b[1];
-
-          if (
-            aValue.Initialize === undefined ||
-            aValue.Initialize.propagated === undefined ||
-            aValue.Initialize.propagated.players === undefined ||
-            bValue.Initialize === undefined ||
-            bValue.Initialize.propagated === undefined ||
-            bValue.Initialize.propagated.players === undefined
-          ) {
-            throw new Error(
-              `failed validation while sorting public rooms between ${aKey} ${bKey}`
-            );
-          }
-
-          const playerDiff =
-            bValue.Initialize.propagated.players.length -
-            aValue.Initialize.propagated.players.length;
-
-          if (playerDiff !== 0) {
-            return playerDiff;
-          }
-
-          return aKey.localeCompare(bKey);
-        });
-        setPublicRooms(resultArray);
+        setPublicRooms(resultJSON);
       };
 
       fetchAsync().catch((e) => {
@@ -106,12 +74,12 @@ const PublicRoomsPane = (): JSX.Element => {
           </LabelCell>
         </Row>
         {publicRooms.length === 0 && <div>No rooms available</div>}
-        {publicRooms.map(([key, value]) => {
+        {publicRooms.map((roomInfo) => {
           return (
             <PublicRoomRow
-              key={key}
-              roomName={key}
-              numPlayers={value.Initialize.propagated.players.length}
+              key={roomInfo.name}
+              roomName={roomInfo.name}
+              numPlayers={roomInfo.num_players}
             />
           );
         })}

--- a/frontend/src/gen-types.d.ts
+++ b/frontend/src/gen-types.d.ts
@@ -130,6 +130,9 @@ export type Action =
       SetTractorRequirements: TractorRequirements;
     }
   | {
+      SetGameVisibility: GameVisibility;
+    }
+  | {
       /**
        * @minItems 2
        * @maxItems 2
@@ -206,6 +209,7 @@ export type BidTakebackPolicy = "AllowBidTakeback" | "NoBidTakeback";
 export type KittyTheftPolicy = "AllowKittyTheft" | "NoKittyTheft";
 export type GameShadowingPolicy = "AllowMultipleSessions" | "SingleSessionOnly";
 export type GameStartPolicy = "AllowAnyPlayer" | "AllowLandlordOnly";
+export type GameVisibility = "Public" | "Unlisted";
 export type Card = string;
 export type TrickUnit =
   | {
@@ -447,6 +451,11 @@ export type MessageVariant =
   | {
       policy: KittyTheftPolicy;
       type: "KittyTheftPolicySet";
+      [k: string]: unknown;
+    }
+  | {
+      type: "GameVisibilitySet";
+      visibility: GameVisibility;
       [k: string]: unknown;
     }
   | {
@@ -866,6 +875,7 @@ export interface PropagatedState {
   game_scoring_parameters?: GameScoringParameters;
   game_shadowing_policy?: GameShadowingPolicy & string;
   game_start_policy?: GameStartPolicy & string;
+  game_visibility?: GameVisibility & string;
   hide_landlord_points?: boolean;
   hide_played_cards?: boolean;
   hide_throw_halting_player?: boolean;

--- a/frontend/src/gen-types.schema.json
+++ b/frontend/src/gen-types.schema.json
@@ -501,6 +501,16 @@
         },
         {
           "type": "object",
+          "required": ["SetGameVisibility"],
+          "properties": {
+            "SetGameVisibility": {
+              "$ref": "#/definitions/GameVisibility"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
           "required": ["Bid"],
           "properties": {
             "Bid": {
@@ -1580,6 +1590,10 @@
         }
       ]
     },
+    "GameVisibility": {
+      "type": "string",
+      "enum": ["Public", "Unlisted"]
+    },
     "Hands": {
       "type": "object",
       "required": ["hands"],
@@ -2021,6 +2035,19 @@
             "type": {
               "type": "string",
               "enum": ["KittyTheftPolicySet"]
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["type", "visibility"],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": ["GameVisibilitySet"]
+            },
+            "visibility": {
+              "$ref": "#/definitions/GameVisibility"
             }
           }
         },
@@ -2762,6 +2789,14 @@
           "allOf": [
             {
               "$ref": "#/definitions/GameStartPolicy"
+            }
+          ]
+        },
+        "game_visibility": {
+          "default": "Unlisted",
+          "allOf": [
+            {
+              "$ref": "#/definitions/GameVisibility"
             }
           ]
         },

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1936,9 +1936,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001286:
-  version "1.0.30001309"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001309.tgz#e0ee78b9bec0704f67304b00ff3c5c0c768a9f62"
-  integrity sha512-Pl8vfigmBXXq+/yUz1jUwULeq9xhMJznzdc/xwl4WclDAuebcTHVefpz8lE/bMI+UN7TOkSSe7B7RnZd6+dzjA==
+  version "1.0.30001458"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001458.tgz"
+  integrity sha512-lQ1VlUUq5q9ro9X+5gOEyH7i3vm+AYVT1WDCVB69XOZ17KZRhnZ9J0Sqz7wTHQaLBJccNCHq8/Ww5LlOIZbB0w==
 
 canvas-confetti@^1.2.0:
   version "1.5.0"


### PR DESCRIPTION
First pass at: https://github.com/rbtying/shengji/issues/49

- Added a GameVisibility field. Defaults to `unlisted`, but can be toggled to `public`. In the future can be used for private games, etc.
- Added a PublicRoomsPane, with functionality to poll a new API that returns all public games and displays them on the first page. Is polled on first render, and then has a refresh button for ad hoc refreshes afterwards.

<img width="1768" alt="Screen Shot 2023-02-24 at 3 34 01 PM" src="https://user-images.githubusercontent.com/3927689/221325091-f22296bc-12af-4f75-8afc-86effcfbaa5b.png">
<img width="1286" alt="Screen Shot 2023-02-24 at 3 34 12 PM" src="https://user-images.githubusercontent.com/3927689/221325097-1a6b9525-f057-49f7-add0-1b5281622211.png">
