### PR TITLE
Prevent boolean defaults from overriding saved values

### DIFF
--- a/frontend/src/localStorageState.ts
+++ b/frontend/src/localStorageState.ts
@@ -19,7 +19,7 @@ export const booleanLocalStorageState = (
 ): State<boolean> =>
   localStorageState(
     key,
-    (value: any): boolean => value === "on" || defaultValue,
+    (value: any): boolean => value === "on" || (value == null && defaultValue),
     (state: boolean) => (state ? "on" : "off")
   );
 


### PR DESCRIPTION
`show_trick_in_player_order` doesn't get remembered properly on refresh because the default can override it. This tweaks how defaults are handled for loading booleans to respect "off" values.