### PR TITLE
Require confirmation to reset game

### DIFF
--- a/core/src/game_state/draw_phase.rs
+++ b/core/src/game_state/draw_phase.rs
@@ -326,7 +326,7 @@ impl DrawPhase {
             Some(p) => {
                 // ignore duplicate reset requests from same player
                 if p == player {
-                    return Ok((None, vec![]))
+                    return Ok((None, vec![]));
                 }
 
                 let (s, m) = self.return_to_initialize()?;

--- a/core/src/game_state/draw_phase.rs
+++ b/core/src/game_state/draw_phase.rs
@@ -32,6 +32,7 @@ pub struct DrawPhase {
     removed_cards: Vec<Card>,
     #[serde(default)]
     decks: Vec<Deck>,
+    player_requested_reset: Option<PlayerID>,
 }
 
 impl DrawPhase {
@@ -61,6 +62,7 @@ impl DrawPhase {
             bids: Vec::new(),
             revealed_cards: 0,
             autobid: None,
+            player_requested_reset: None,
         }
     }
 
@@ -316,7 +318,36 @@ impl DrawPhase {
         ))
     }
 
-    pub fn return_to_initialize(&self) -> Result<(InitializePhase, Vec<MessageVariant>), Error> {
+    pub fn request_reset(
+        &mut self,
+        player: PlayerID,
+    ) -> Result<(Option<InitializePhase>, Vec<MessageVariant>), Error> {
+        match self.player_requested_reset {
+            Some(p) => {
+                // ignore duplicate reset requests from same player
+                if p == player {
+                    return Ok((None, vec![]))
+                }
+
+                let (s, m) = self.return_to_initialize()?;
+                Ok((Some(s), m))
+            }
+            None => {
+                self.player_requested_reset = Some(player);
+                Ok((None, vec![MessageVariant::ResetRequested]))
+            }
+        }
+    }
+
+    pub fn cancel_reset(&mut self) -> Option<MessageVariant> {
+        if self.player_requested_reset.is_some() {
+            self.player_requested_reset = None;
+            return Some(MessageVariant::ResetCanceled);
+        }
+        None
+    }
+
+    fn return_to_initialize(&self) -> Result<(InitializePhase, Vec<MessageVariant>), Error> {
         let mut msgs = vec![MessageVariant::ResettingGame];
 
         let mut propagated = self.propagated.clone();

--- a/core/src/game_state/exchange_phase.rs
+++ b/core/src/game_state/exchange_phase.rs
@@ -397,7 +397,7 @@ impl ExchangePhase {
             Some(p) => {
                 // ignore duplicate reset requests from same player
                 if p == player {
-                    return Ok((None, vec![]))
+                    return Ok((None, vec![]));
                 }
 
                 let (s, m) = self.return_to_initialize()?;

--- a/core/src/game_state/mod.rs
+++ b/core/src/game_state/mod.rs
@@ -115,25 +115,53 @@ impl GameState {
         }
     }
 
-    pub fn reset(&mut self) -> Result<Vec<MessageVariant>, Error> {
+    pub fn request_reset(&mut self, player: PlayerID) -> Result<Vec<MessageVariant>, Error> {
         match self {
             GameState::Initialize(_) => bail!("Game has not started yet!"),
             GameState::Draw(ref mut p) => {
-                let (s, m) = p.return_to_initialize()?;
-                *self = GameState::Initialize(s);
+                let (s, m) = p.request_reset(player)?;
+                if let Some(s) = s {
+                    *self = GameState::Initialize(s);
+                }
                 Ok(m)
             }
             GameState::Exchange(ref mut p) => {
-                let (s, m) = p.return_to_initialize()?;
-                *self = GameState::Initialize(s);
+                let (s, m) = p.request_reset(player)?;
+                if let Some(s) = s {
+                    *self = GameState::Initialize(s);
+                }
                 Ok(m)
             }
             GameState::Play(ref mut p) => {
-                let (s, m) = p.return_to_initialize()?;
-                *self = GameState::Initialize(s);
+                let (s, m) = p.request_reset(player)?;
+                if let Some(s) = s {
+                    *self = GameState::Initialize(s);
+                }
                 Ok(m)
             }
         }
+    }
+
+    pub fn cancel_reset(&mut self) -> Result<Vec<MessageVariant>, Error> {
+        match self {
+            GameState::Initialize(_) => bail!("Game has not started yet!"),
+            GameState::Draw(ref mut p) => {
+                if let Some(m) = p.cancel_reset() {
+                    return Ok(vec![m]);
+                }
+            }
+            GameState::Exchange(ref mut p) => {
+                if let Some(m) = p.cancel_reset() {
+                    return Ok(vec![m]);
+                }
+            }
+            GameState::Play(ref mut p) => {
+                if let Some(m) = p.cancel_reset() {
+                    return Ok(vec![m]);
+                }
+            }
+        }
+        Ok(vec![])
     }
 
     pub fn for_player(&self, id: PlayerID) -> GameState {

--- a/core/src/game_state/play_phase.rs
+++ b/core/src/game_state/play_phase.rs
@@ -591,7 +591,7 @@ impl PlayPhase {
             Some(p) => {
                 // ignore duplicate reset requests from same player
                 if p == player {
-                    return Ok((None, vec![]))
+                    return Ok((None, vec![]));
                 }
 
                 let (s, m) = self.return_to_initialize()?;

--- a/core/src/interactive.rs
+++ b/core/src/interactive.rs
@@ -92,8 +92,12 @@ impl InteractiveGame {
 
         let msgs = match (msg, &mut self.state) {
             (Action::ResetGame, _) => {
-                info!(logger, "Resetting game");
-                self.state.reset()?
+                info!(logger, "Requesting game reset");
+                self.state.request_reset(id)?
+            }
+            (Action::CancelResetGame, _) => {
+                info!(logger, "Cancelling game reset request");
+                self.state.cancel_reset()?
             }
             (Action::SetChatLink(ref link), _) => {
                 self.state.set_chat_link(link.clone())?;
@@ -413,6 +417,7 @@ impl InteractiveGame {
 
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub enum Action {
+    CancelResetGame,
     ResetGame,
     MakeObserver(PlayerID),
     MakePlayer(PlayerID),

--- a/core/src/message.rs
+++ b/core/src/message.rs
@@ -21,6 +21,8 @@ use crate::settings::{
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(tag = "type")]
 pub enum MessageVariant {
+    ResetRequested,
+    ResetCanceled,
     ResettingGame,
     StartingGame,
     TrickWon {
@@ -199,6 +201,8 @@ impl MessageVariant {
 
         use MessageVariant::*;
         Ok(match self {
+            ResetRequested => format!("{} requested game reset", n?),
+            ResetCanceled => format!("{} canceled game reset", n?),
             ResettingGame => format!("{} reset the game", n?),
             StartingGame => format!("{} started the game", n?),
             TrickWon { winner, points: 0 } =>

--- a/frontend/src/Credits.tsx
+++ b/frontend/src/Credits.tsx
@@ -61,7 +61,10 @@ const ChangeLog = (): JSX.Element => {
         <h2>Change Log</h2>
         <p>7/10/2023:</p>
         <ul>
-          <li>Added a confirmation check when resetting the game</li>
+          <li>
+            Added a confirmation check from another player when resetting the
+            game
+          </li>
         </ul>
         <p>2/24/2023:</p>
         <ul>

--- a/frontend/src/Credits.tsx
+++ b/frontend/src/Credits.tsx
@@ -59,6 +59,10 @@ const ChangeLog = (): JSX.Element => {
           you&apos;re in the game.
         </p>
         <h2>Change Log</h2>
+        <p>7/10/2023:</p>
+        <ul>
+          <li>Added a confirmation check when resetting the game</li>
+        </ul>
         <p>2/24/2023:</p>
         <ul>
           <li>
@@ -193,9 +197,8 @@ const ChangeLog = (): JSX.Element => {
         <p>1/18/2021:</p>
         <ul>
           <li>
-            Ammend the &ldquo;PointCardNotAllowed&rdquo; friend selection
-            policy. King is now a valid friend when the landlord&apos;s rank is
-            Ace.
+            Amend the &ldquo;PointCardNotAllowed&rdquo; friend selection policy.
+            King is now a valid friend when the landlord&apos;s rank is Ace.
           </li>
         </ul>
         <p>1/8/2021:</p>

--- a/frontend/src/ResetButton.tsx
+++ b/frontend/src/ResetButton.tsx
@@ -1,0 +1,93 @@
+import * as React from "react";
+import { WebsocketContext } from "./WebsocketProvider";
+import { GameState } from "./gen-types";
+
+interface IProps {
+  state: GameState;
+  name: string;
+}
+
+const ResetButton = (props: IProps): JSX.Element => {
+  const { send } = React.useContext(WebsocketContext);
+
+  let requester: string = null;
+  if ("Draw" in props.state) {
+    const state = props.state.Draw;
+    requester = state.propagated.players.find(
+      (player) => player.id === state.player_requested_reset
+    )?.name;
+  } else if ("Exchange" in props.state) {
+    const state = props.state.Exchange;
+    requester = state.propagated.players.find(
+      (player) => player.id === state.player_requested_reset
+    )?.name;
+  } else if ("Play" in props.state) {
+    const state = props.state.Play;
+    requester = state.propagated.players.find(
+      (player) => player.id === state.player_requested_reset
+    )?.name;
+  }
+
+  if (requester == null) {
+    return (
+      <div className="reset-block">
+        <a
+          href={window.location.href}
+          onClick={(evt) => {
+            evt.preventDefault();
+            send({ Action: "ResetGame" });
+          }}
+          title="Request to return to the game settings screen and re-deal all cards"
+        >
+          Reset game
+        </a>
+      </div>
+    );
+  } else if (requester === props.name) {
+    return (
+      <div className="reset-block">
+        <p>Waiting for confirmation...</p>
+        <a
+          href={window.location.href}
+          onClick={(evt) => {
+            evt.preventDefault();
+            send({ Action: "CancelResetGame" });
+          }}
+          title="Continue playing the game"
+        >
+          Cancel
+        </a>
+      </div>
+    );
+  } else {
+    return (
+      <div className="reset-block">
+        <p>{requester} wants to reset the game</p>
+        <a
+          href={window.location.href}
+          onClick={(evt) => {
+            send({ Action: "ResetGame" });
+          }}
+          title="Return to the game settings screen and re-deal all cards"
+          style={{
+            marginRight: "8px",
+          }}
+        >
+          Accept
+        </a>
+        <a
+          href={window.location.href}
+          onClick={(evt) => {
+            evt.preventDefault();
+            send({ Action: "CancelResetGame" });
+          }}
+          title="Continue playing the game"
+        >
+          Cancel
+        </a>
+      </div>
+    );
+  }
+};
+
+export default ResetButton;

--- a/frontend/src/Root.tsx
+++ b/frontend/src/Root.tsx
@@ -12,11 +12,11 @@ import Chat from "./Chat";
 import Play from "./Play";
 import DebugInfo from "./DebugInfo";
 import TitleHandler from "./TitleHandler";
+import ResetButton from "./ResetButton";
 
 const Confetti = React.lazy(async () => await import("./Confetti"));
 
 const Root = (): JSX.Element => {
-  const send = (window as any).send;
   const { state, updateState } = React.useContext(AppStateContext);
   const timerContext = React.useContext(TimerContext);
 
@@ -108,19 +108,7 @@ const Root = (): JSX.Element => {
           ) : null}
           <div className="game">
             {"Initialize" in state.gameState ? null : (
-              <a
-                href={window.location.href}
-                className="reset-link"
-                onClick={(evt) => {
-                  evt.preventDefault();
-                  if (window.confirm("Do you really want to reset the game?")) {
-                    send({ Action: "ResetGame" });
-                  }
-                }}
-                title="Return to the game settings screen and re-deal all cards"
-              >
-                Reset game
-              </a>
+              <ResetButton state={state.gameState} name={state.name} />
             )}
             {"Initialize" in state.gameState ? (
               <Initialize

--- a/frontend/src/gen-types.d.ts
+++ b/frontend/src/gen-types.d.ts
@@ -7,6 +7,7 @@
 
 export type Action =
   | (
+      | "CancelResetGame"
       | "ResetGame"
       | "StartGame"
       | "DrawCard"
@@ -319,6 +320,14 @@ export type GameMode =
       };
     };
 export type MessageVariant =
+  | {
+      type: "ResetRequested";
+      [k: string]: unknown;
+    }
+  | {
+      type: "ResetCanceled";
+      [k: string]: unknown;
+    }
   | {
       type: "ResettingGame";
       [k: string]: unknown;
@@ -912,6 +921,7 @@ export interface DrawPhase {
   kitty: Card[];
   level?: MaxRank | null;
   num_decks: number;
+  player_requested_reset?: number | null;
   position: number;
   propagated: PropagatedState;
   removed_cards?: Card[];
@@ -938,6 +948,7 @@ export interface ExchangePhase {
   kitty_size: number;
   landlord: number;
   num_decks: number;
+  player_requested_reset?: number | null;
   propagated: PropagatedState;
   removed_cards?: Card[];
   trump: Trump;
@@ -957,6 +968,7 @@ export interface PlayPhase {
   penalties: {
     [k: string]: number;
   };
+  player_requested_reset?: number | null;
   points: {
     [k: string]: Card[];
   };

--- a/frontend/src/gen-types.schema.json
+++ b/frontend/src/gen-types.schema.json
@@ -104,6 +104,7 @@
         {
           "type": "string",
           "enum": [
+            "CancelResetGame",
             "ResetGame",
             "StartGame",
             "DrawCard",
@@ -944,6 +945,11 @@
           "format": "uint",
           "minimum": 0.0
         },
+        "player_requested_reset": {
+          "type": ["integer", "null"],
+          "format": "uint",
+          "minimum": 0.0
+        },
         "position": {
           "type": "integer",
           "format": "uint",
@@ -1049,6 +1055,11 @@
         },
         "num_decks": {
           "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "player_requested_reset": {
+          "type": ["integer", "null"],
           "format": "uint",
           "minimum": 0.0
         },
@@ -1656,6 +1667,26 @@
     },
     "MessageVariant": {
       "oneOf": [
+        {
+          "type": "object",
+          "required": ["type"],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": ["ResetRequested"]
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["type"],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": ["ResetCanceled"]
+            }
+          }
+        },
         {
           "type": "object",
           "required": ["type"],
@@ -2588,6 +2619,11 @@
             "format": "uint",
             "minimum": 0.0
           }
+        },
+        "player_requested_reset": {
+          "type": ["integer", "null"],
+          "format": "uint",
+          "minimum": 0.0
         },
         "points": {
           "type": "object",

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -422,8 +422,14 @@ button.normal {
   margin: 10px;
 }
 
-.reset-link {
+.reset-block {
   float: right;
+  text-align: center;
+  width: 200px;
+}
+
+.reset-block p {
+  margin-block: 0;
 }
 
 .red {


### PR DESCRIPTION
Fixes #93 

Some notes:
 - anyone is allowed to cancel the game resetting, not only the requestor
 - there's a fair amount of duplicate code for handling the action, which already existed with the previous reset implementation. Happy to take a crack at refactoring that if you find it useful.
 - thanks for making this game!

 
<img width="1840" alt="Screen Shot 2023-07-10 at 5 30 02 PM" src="https://github.com/rbtying/shengji/assets/5728920/0e4e0709-fafc-4a02-bbd0-483d4dddd8a5">

<img width="1840" alt="Screen Shot 2023-07-10 at 5 29 57 PM" src="https://github.com/rbtying/shengji/assets/5728920/5580f9d4-f072-499e-a8e9-316fe787045e">

