### PR TITLE
Fix bug with double suits being able to outbid double joker

### DIFF
--- a/mechanics/src/bidding.rs
+++ b/mechanics/src/bidding.rs
@@ -526,6 +526,31 @@ mod tests {
                 BidReinforcementPolicy::ReinforceWhileWinning,
                 vec![b!(p, C_2, 3)],
             ),
+            (
+                vec![b!(p, C_2, 1), b!(PlayerID(1), Card::SmallJoker, 2)],
+                BidReinforcementPolicy::ReinforceWhileWinning,
+                vec![
+                    b!(p, C_2, 3),
+                    b!(p, Card::BigJoker, 2),
+                ],
+            ),
+            (
+                vec![b!(p, C_2, 1), b!(PlayerID(1), Card::BigJoker, 2)],
+                BidReinforcementPolicy::ReinforceWhileWinning,
+                vec![
+                    b!(p, C_2, 3),
+                ],
+            ),
+            (
+                vec![b!(p, C_2, 1), b!(PlayerID(1), Card::SmallJoker, 3)],
+                BidReinforcementPolicy::ReinforceWhileWinning,
+                vec![],
+            ),
+            (
+                vec![b!(p, C_2, 1), b!(PlayerID(1), Card::BigJoker, 3)],
+                BidReinforcementPolicy::ReinforceWhileWinning,
+                vec![],
+            ),
         ];
 
         for (bids, rpol, results) in test_cases_higher_suit {

--- a/mechanics/src/bidding.rs
+++ b/mechanics/src/bidding.rs
@@ -158,6 +158,8 @@ impl Bid {
                                         (Card::SmallJoker, Card::BigJoker)
                                         | (Card::SmallJoker, Card::SmallJoker) => (),
                                         (Card::SmallJoker, _) => valid_bids.push(new_bid),
+                                        (_, Card::BigJoker)
+                                        | (_, Card::SmallJoker) => (),
                                         _ => {
                                             // The new bid count must have a size of at least 2 in
                                             // order to be compared by suit ranking

--- a/mechanics/src/bidding.rs
+++ b/mechanics/src/bidding.rs
@@ -158,8 +158,7 @@ impl Bid {
                                         (Card::SmallJoker, Card::BigJoker)
                                         | (Card::SmallJoker, Card::SmallJoker) => (),
                                         (Card::SmallJoker, _) => valid_bids.push(new_bid),
-                                        (_, Card::BigJoker)
-                                        | (_, Card::SmallJoker) => (),
+                                        (_, Card::BigJoker) | (_, Card::SmallJoker) => (),
                                         _ => {
                                             // The new bid count must have a size of at least 2 in
                                             // order to be compared by suit ranking
@@ -529,17 +528,12 @@ mod tests {
             (
                 vec![b!(p, C_2, 1), b!(PlayerID(1), Card::SmallJoker, 2)],
                 BidReinforcementPolicy::ReinforceWhileWinning,
-                vec![
-                    b!(p, C_2, 3),
-                    b!(p, Card::BigJoker, 2),
-                ],
+                vec![b!(p, C_2, 3), b!(p, Card::BigJoker, 2)],
             ),
             (
                 vec![b!(p, C_2, 1), b!(PlayerID(1), Card::BigJoker, 2)],
                 BidReinforcementPolicy::ReinforceWhileWinning,
-                vec![
-                    b!(p, C_2, 3),
-                ],
+                vec![b!(p, C_2, 3)],
             ),
             (
                 vec![b!(p, C_2, 1), b!(PlayerID(1), Card::SmallJoker, 3)],


### PR DESCRIPTION
Bug: Currently this bidding sequence at rank 2 is possible: 1x2D -> 2xLJ -> 2xHJ -> 2x2S -> 2xHJ -> 2x2H -> 2xHJ etc
Expected behaviour: Double of any suit should not be able to outbid double jokers
Actual behaviour: Double of any suit can outbid double jokers, so bidding can become an infinite loop

This is because in the fallback condition `new_bid.card.suit() > existing_bid.card.suit()`, jokers have a none value or something, so any suit is considered higher, so I added an additional condition before that.



Separately, currently this behaviour is enforced: `The new bid count must have a size of at least 2 in order to be compared by suit ranking`, so you can't have 1x2D -> 1x2S. I've never heard of this condition though, my gaming groups have always allowed that, and this behaviour is not expected from the option description `Joker or higher suit bids to outbid non-joker bids with the same number of cards`. Would it be okay if I add a new option for that and update the text of the current one?