### PR TITLE
Fix rules link

### DIFF
--- a/frontend/src/JoinRoom.tsx
+++ b/frontend/src/JoinRoom.tsx
@@ -120,7 +120,7 @@ const JoinRoom = (props: IProps): JSX.Element => {
         </p>
         <p>
           If you&apos;re unfamiliar with the game, it might be helpful to{" "}
-          <a href="rules" target="_blank">
+          <a href="rules.html" target="_blank">
             read the rules
           </a>{" "}
           and then shadow another player&mdash;you can just join with the same


### PR DESCRIPTION

![Screenshot 2024-01-12 at 4 54 57 PM](https://github.com/rbtying/shengji/assets/16202187/f803041d-5c0f-4fbf-8bdb-ba8412e33b19)

If you hover over the `rules` hyperlink, it redirects to `https://robertying.com/shengji/rules`, which leads to a 404. Map it back to the actual page: `https://robertying.com/shengji/rules.html`.