### PR TITLE
fix: TerserJsPlugin in Webpack build was unused

### DIFF
--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -48,7 +48,9 @@ module.exports = {
     },
     minimizer: [
       (compiler) => () => {
-        new TerserPlugin({ terserOptions: { sourceMap: true } }).apply(compiler);
+        new TerserJsPlugin({ terserOptions: { sourceMap: true } }).apply(
+          compiler
+        );
       },
       new CssMinimizerPlugin({}),
     ],


### PR DESCRIPTION
This looked like a typo. Note that the import is `TerserJsPlugin`, not `TerserPlugin`.