### PR TITLE
Feature: Add Max Players Game Setting and Fix Join Logic

### DIFF
--- a/backend/src/shengji_handler.rs
+++ b/backend/src/shengji_handler.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use slog::{debug, error, info, o, Logger};
 use tokio::sync::{mpsc, oneshot, Mutex};
+use tokio::time::{sleep, Duration};
 
 use shengji_core::interactive::InteractiveGame;
 use shengji_mechanics::types::PlayerID;
@@ -82,18 +83,18 @@ async fn handle_user_connected<S: Storage<VersionedGame, E>, E: std::fmt::Debug 
         }
     };
 
-    // Subscribe to messages for the room. After this point, we should
-    // no longer use tx! It's owned by the backend storage.
-    let (subscribe_player_id_tx, subscribe_player_id_rx) = oneshot::channel::<PlayerID>();
+    // Spawn the subscription task *before* attempting registration.
+    // Use Option<PlayerID> in the channel.
+    let (subscribe_player_id_tx, subscribe_player_id_rx) = oneshot::channel::<Option<PlayerID>>();
     tokio::task::spawn(player_subscribe_task(
         logger.clone(),
         name.clone(),
-        tx.clone(),
+        tx.clone(), // Clone tx for the task
         subscribe_player_id_rx,
         subscription,
     ));
 
-    let (player_id, join_span) = register_user(
+    let registration_result = register_user(
         logger.clone(),
         name.clone(),
         ws_id,
@@ -101,12 +102,21 @@ async fn handle_user_connected<S: Storage<VersionedGame, E>, E: std::fmt::Debug 
         backend_storage.clone(),
         stats.clone(),
     )
-    .await
-    .map_err(|_| anyhow::anyhow!("Failed to register user"))?;
+    .await;
+
+    let (player_id, join_span) = match registration_result {
+        Ok(result) => result,
+        Err(e) => {
+            error!(logger, "User registration failed (error sent to client)"; "error" => format!("{:?}", e));
+            let _ = subscribe_player_id_tx.send(None);
+            sleep(Duration::from_secs(2)).await;
+            return Ok(());
+        }
+    };
 
     let logger = logger.new(o!("player_id" => player_id.0));
     info!(logger, "Successfully registered user");
-    let _ = subscribe_player_id_tx.send(player_id);
+    let _ = subscribe_player_id_tx.send(Some(player_id));
 
     run_game_for_player(
         logger.clone(),
@@ -129,13 +139,13 @@ async fn player_subscribe_task(
     logger_: Logger,
     name_: String,
     tx: mpsc::UnboundedSender<Vec<u8>>,
-    subscribe_player_id_rx: oneshot::Receiver<PlayerID>,
+    subscribe_player_id_rx: oneshot::Receiver<Option<PlayerID>>,
     mut subscription: mpsc::UnboundedReceiver<GameMessage>,
 ) {
     debug!(logger_, "Subscribed to messages");
-    if let Ok(player_id) = subscribe_player_id_rx.await {
-        let logger_ = logger_.new(o!("player_id" => player_id.0));
-        debug!(logger_, "Received player ID");
+    if let Ok(player_id_option) = subscribe_player_id_rx.await {
+        let logger_ = logger_.new(o!("player_id" => format!("{:?}", player_id_option.map(|p|p.0))));
+        debug!(logger_, "Received player ID option");
         while let Some(v) = subscription.recv().await {
             let should_send = match &v {
                 GameMessage::State { .. }
@@ -146,25 +156,35 @@ async fn player_subscribe_task(
                 GameMessage::Beep { target } | GameMessage::Kicked { target } => *target == name_,
                 GameMessage::ReadyCheck { from } => *from != name_,
             };
+
             let v = if should_send {
-                if let GameMessage::State { state } = v {
-                    let g = InteractiveGame::new_from_state(state);
-                    g.dump_state_for_player(player_id)
-                        .ok()
-                        .map(|state| GameMessage::State { state })
-                } else {
-                    Some(v)
+                // Only filter state if we have a valid player ID
+                // Match on player_id_option first, then check if 'v' is GameMessage::State
+                match player_id_option {
+                    Some(player_id) => {
+                        if let GameMessage::State { state } = v {
+                            let g = InteractiveGame::new_from_state(state);
+                            g.dump_state_for_player(player_id)
+                                .ok()
+                                .map(|filtered_state| GameMessage::State { state: filtered_state })
+                        } else {
+                            Some(v)
+                        }
+                    }
+                    None => Some(v),
                 }
             } else {
                 None
             };
 
-            if let Some(v) = v {
-                if send_to_user(&tx, &v).await.is_err() {
+            if let Some(v_to_send) = v {
+                if send_to_user(&tx, &v_to_send).await.is_err() {
                     break;
                 }
             }
         }
+    } else {
+        error!(logger_, "Failed to receive player ID option from oneshot channel");
     }
     debug!(logger_, "Subscription task completed");
 }
@@ -176,11 +196,11 @@ async fn register_user<S: Storage<VersionedGame, E>, E: std::fmt::Debug + Send>(
     room: String,
     backend_storage: S,
     stats: Arc<Mutex<InMemoryStats>>,
-) -> Result<(PlayerID, u64), ()> {
+) -> Result<(PlayerID, u64), anyhow::Error> {
     let (player_id_tx, player_id_rx) = oneshot::channel();
     let logger_ = logger.clone();
     let name_ = name.clone();
-    execute_operation(
+    let exec_result = execute_operation(
         ws_id,
         &room,
         backend_storage.clone(),
@@ -198,7 +218,7 @@ async fn register_user<S: Storage<VersionedGame, E>, E: std::fmt::Debug + Send>(
 
             player_id_tx
                 .send((assigned_player_id, version, clients_to_disconnect))
-                .map_err(|_| anyhow::anyhow!("Couldn't send player ID back".to_owned()))?;
+                .map_err(|_| anyhow::anyhow!("Receiver dropped before player ID could be sent"))?;
             Ok(register_msgs
                 .into_iter()
                 .map(|(data, message)| GameMessage::Broadcast { data, message })
@@ -207,6 +227,10 @@ async fn register_user<S: Storage<VersionedGame, E>, E: std::fmt::Debug + Send>(
         "register game",
     )
     .await;
+
+    if let Err(e) = exec_result {
+        return Err(e);
+    }
 
     let header_messages = {
         let stats = stats.lock().await;
@@ -223,23 +247,26 @@ async fn register_user<S: Storage<VersionedGame, E>, E: std::fmt::Debug + Send>(
         )
         .await;
 
-    if let Ok((player_id, ws_id, websockets_to_disconnect)) = player_id_rx.await {
-        for id in websockets_to_disconnect {
-            info!(logger, "Disconnnecting existing client"; "kicked_ws_id" => id);
-            let _ = backend_storage
-                .clone()
-                .publish_to_single_subscriber(
-                    room.as_bytes().to_vec(),
-                    id,
-                    GameMessage::Kicked {
-                        target: name.clone(),
-                    },
-                )
-                .await;
+    match player_id_rx.await {
+        Ok((player_id, version, websockets_to_disconnect)) => {
+            for id in websockets_to_disconnect {
+                info!(logger, "Disconnnecting existing client"; "kicked_ws_id" => id);
+                let _ = backend_storage
+                    .clone()
+                    .publish_to_single_subscriber(
+                        room.as_bytes().to_vec(),
+                        id,
+                        GameMessage::Kicked {
+                            target: name.clone(),
+                        },
+                    )
+                    .await;
+            }
+            Ok((player_id, version))
         }
-        Ok((player_id, ws_id))
-    } else {
-        Err(())
+        Err(_) => {
+            Err(anyhow::anyhow!("Failed to receive player ID after registration operation"))
+        }
     }
 }
 
@@ -294,7 +321,7 @@ async fn run_game_for_player<S: Storage<VersionedGame, E>, E: Send + std::fmt::D
     debug!(logger, "Exiting main game loop");
 }
 
-async fn handle_user_action<S: Storage<VersionedGame, E>, E: Send>(
+async fn handle_user_action<S: Storage<VersionedGame, E>, E: Send + std::fmt::Debug>(
     logger: Logger,
     ws_id: usize,
     caller: PlayerID,
@@ -305,7 +332,7 @@ async fn handle_user_action<S: Storage<VersionedGame, E>, E: Send>(
 ) -> Result<(), E> {
     match msg {
         UserMessage::Beep => {
-            execute_immutable_operation(
+            if let Err(e) = execute_immutable_operation(
                 ws_id,
                 room_name,
                 backend_storage,
@@ -324,7 +351,9 @@ async fn handle_user_action<S: Storage<VersionedGame, E>, E: Send>(
                 },
                 "send appropriate beep",
             )
-            .await;
+            .await {
+                error!(logger, "Beep operation failed"; "error" => format!("{:?}", e));
+            }
         }
         UserMessage::Message(m) => {
             backend_storage
@@ -368,7 +397,7 @@ async fn handle_user_action<S: Storage<VersionedGame, E>, E: Send>(
         }
         UserMessage::Kick(id) => {
             info!(logger, "Kicking user"; "other" => id.0);
-            execute_operation(
+            if let Err(e) = execute_operation(
                 ws_id,
                 room_name,
                 backend_storage,
@@ -379,56 +408,70 @@ async fn handle_user_action<S: Storage<VersionedGame, E>, E: Send>(
                         target: kicked_player_name,
                     }])
                 },
-                "kick user",
+                "kick player",
             )
-            .await;
+            .await {
+                error!(logger, "Kick operation failed"; "target_id" => id.0, "error" => format!("{:?}", e));
+            }
         }
         UserMessage::Action(action) => {
-            execute_operation(
+            let action_clone_for_log = action.clone();
+            let logger_clone_for_log = logger.clone();
+            if let Err(e) = execute_operation(
                 ws_id,
                 room_name,
                 backend_storage,
-                move |game, _, _| {
-                    Ok(game
-                        .interact(action, caller, &logger)?
-                        .into_iter()
-                        .map(|(data, message)| GameMessage::Broadcast { data, message })
-                        .collect())
+                move |g, _version, _| {
+                    g.interact(action, caller, &logger).map(|msgs| {
+                        msgs.into_iter()
+                            .map(|(data, message)| GameMessage::Broadcast { data, message })
+                            .collect()
+                    })
                 },
-                "handle user action",
+                "perform action",
             )
-            .await;
+            .await {
+                error!(logger_clone_for_log, "Action execution failed"; "action" => format!("{:?}", action_clone_for_log), "error" => format!("{:?}", e));
+            }
         }
     }
     Ok(())
 }
 
-async fn user_disconnected<S: Storage<VersionedGame, E>, E: Send>(
+async fn user_disconnected<S: Storage<VersionedGame, E>, E: Send + std::fmt::Debug>(
     room: String,
     ws_id: usize,
     backend_storage: S,
     logger: slog::Logger,
     parent: u64,
 ) {
-    execute_operation(
+    let room_name = room.as_bytes().to_vec();
+    let room_name_str = String::from_utf8_lossy(&room_name);
+
+    info!(logger, "User disconnected, cleaning up websocket association");
+
+    // Clean up websocket association
+    if let Err(e) = execute_operation(
         ws_id,
-        &room,
+        &room_name_str,
         backend_storage.clone(),
-        move |_, _, associated_websockets| {
-            for ws in associated_websockets.values_mut() {
-                ws.retain(|w| *w != ws_id);
+        move |_g, _, associated_websockets| {
+            for player_websockets in associated_websockets.values_mut() {
+                player_websockets.retain(|id| *id != ws_id);
             }
+            associated_websockets.retain(|_, player_websockets| !player_websockets.is_empty());
             Ok(vec![])
         },
-        "disconnect player",
+        "clean up disconnected websocket",
     )
-    .await;
-    backend_storage
-        .unsubscribe(room.as_bytes().to_vec(), ws_id)
+    .await
+    {
+        error!(logger, "Failed to clean up websocket association on disconnect"; "error" => format!("{:?}", e));
+    }
+
+    let _ = backend_storage
+        .unsubscribe(room_name, ws_id)
         .await;
-    info!(logger, "Websocket disconnected";
-        "room" => room,
-        "parent_span" => format!("{room}:{parent}"),
-        "span" => format!("{room}:ws_{ws_id}")
-    );
+
+    info!(logger, "Finished user disconnected cleanup"; "parent_id" => parent);
 }

--- a/backend/src/state_dump.rs
+++ b/backend/src/state_dump.rs
@@ -33,6 +33,7 @@ impl InMemoryStats {
 pub struct PublicGameInfo {
     name: String,
     num_players: usize,
+    max_players: Option<usize>,
 }
 
 pub async fn load_dump_file<S: Storage<VersionedGame, E>, E: Send + std::fmt::Debug>(
@@ -202,6 +203,7 @@ pub async fn public_games(
                     public_games.push(PublicGameInfo {
                         name,
                         num_players: versioned_game.game.players().len(),
+                        max_players: versioned_game.game.max_players(),
                     });
                 }
             }

--- a/core/src/interactive.rs
+++ b/core/src/interactive.rs
@@ -391,6 +391,10 @@ impl InteractiveGame {
                 self.state = GameState::Initialize(new_s);
                 msgs
             }
+            (Action::SetMaxPlayers(max_players), GameState::Initialize(ref mut state)) => {
+                info!(logger, "Setting max players"; "max_players" => max_players);
+                state.set_max_players(max_players)?
+            }
             _ => bail!("not supported in current phase"),
         };
 
@@ -461,6 +465,7 @@ pub enum Action {
     SetJackVariation(BackToTwoSetting),
     SetTractorRequirements(TractorRequirements),
     SetGameVisibility(GameVisibility),
+    SetMaxPlayers(Option<usize>),
     StartGame,
     DrawCard,
     RevealCard,

--- a/core/src/message.rs
+++ b/core/src/message.rs
@@ -192,6 +192,9 @@ pub enum MessageVariant {
     TractorRequirementsChanged {
         tractor_requirements: TractorRequirements,
     },
+    MaxPlayersSet {
+        max_players: Option<usize>,
+    },
 }
 
 impl MessageVariant {
@@ -382,9 +385,11 @@ impl MessageVariant {
             JackVariation { variation: BackToTwoSetting::SingleJack } => format!("{} enabled the single jack variation", n?),
             JackVariation { variation: BackToTwoSetting::Disabled } => format!("{} disabled the jack variation", n?),
             TractorRequirementsChanged { tractor_requirements } =>
-                format!("{} required tractors to be at least {} cards wide by {} tuples long", n?, tractor_requirements.min_count, tractor_requirements.min_length),
+                format!("{} changed the tractor requirements: {:?}", n?, tractor_requirements),
             GameVisibilitySet { visibility: GameVisibility::Public} => format!("{} listed the game publicly", n?),
             GameVisibilitySet { visibility: GameVisibility::Unlisted} => format!("{} unlisted the game", n?),
+            MaxPlayersSet { max_players: Some(max_players) } => format!("{} set the maximum number of players to {}", n?, max_players),
+            MaxPlayersSet { max_players: None } => format!("{} removed the maximum number of players limit", n?),
         })
     }
 }

--- a/core/src/message.rs
+++ b/core/src/message.rs
@@ -385,7 +385,7 @@ impl MessageVariant {
             JackVariation { variation: BackToTwoSetting::SingleJack } => format!("{} enabled the single jack variation", n?),
             JackVariation { variation: BackToTwoSetting::Disabled } => format!("{} disabled the jack variation", n?),
             TractorRequirementsChanged { tractor_requirements } =>
-                format!("{} changed the tractor requirements: {:?}", n?, tractor_requirements),
+                format!("{} required tractors to be at least {} cards wide by {} tuples long", n?, tractor_requirements.min_count, tractor_requirements.min_length),
             GameVisibilitySet { visibility: GameVisibility::Public} => format!("{} listed the game publicly", n?),
             GameVisibilitySet { visibility: GameVisibility::Unlisted} => format!("{} unlisted the game", n?),
             MaxPlayersSet { max_players: Some(max_players) } => format!("{} set the maximum number of players to {}", n?, max_players),

--- a/core/src/settings.rs
+++ b/core/src/settings.rs
@@ -938,4 +938,8 @@ impl PropagatedState {
         self.max_players = max_players;
         Ok(vec![MessageVariant::MaxPlayersSet { max_players }])
     }
+
+    pub fn max_players(&self) -> Option<usize> {
+        self.max_players
+    }
 }

--- a/frontend/src/AppStateProvider.tsx
+++ b/frontend/src/AppStateProvider.tsx
@@ -22,6 +22,8 @@ export interface AppState {
   messages: Message[];
   confetti: string | null;
   changeLogLastViewed: number;
+  joinError: string | null;
+  connectionNonce: number;
 }
 
 const appState: State<AppState> = combineState({
@@ -37,6 +39,8 @@ const appState: State<AppState> = combineState({
   errors: noPersistence<string[]>(() => []),
   messages: noPersistence<Message[]>(() => []),
   confetti: noPersistence<string | null>(() => null),
+  joinError: noPersistence<string | null>(() => null),
+  connectionNonce: noPersistence<number>(() => 0),
 });
 
 interface Context {

--- a/frontend/src/Initialize.tsx
+++ b/frontend/src/Initialize.tsx
@@ -1095,6 +1095,13 @@ const Initialize = (props: IProps): JSX.Element => {
               },
             });
             break;
+          case "max_players":
+            send({
+              Action: {
+                SetMaxPlayers: value,
+              },
+            });
+            break;
         }
       }
     }
@@ -1150,6 +1157,12 @@ const Initialize = (props: IProps): JSX.Element => {
     };
 
     fetchAsync().catch((e) => console.error(e));
+  };
+
+  const setMaxPlayers = (evt: React.ChangeEvent<HTMLInputElement>): void => {
+    evt.preventDefault();
+    const num = parseInt(evt.target.value, 10);
+    send({ Action: { SetMaxPlayers: isNaN(num) ? null : num } });
   };
 
   return (
@@ -1345,6 +1358,17 @@ const Initialize = (props: IProps): JSX.Element => {
               <option value={"Unlisted"}>Unlisted</option>
               <option value={"Public"}>Public</option>
             </select>
+          </label>
+        </div>
+        <div>
+          <label>
+            Max players:{" "}
+            <input
+              type="number"
+              min={props.state.propagated.players.length}
+              value={props.state.propagated.max_players ?? ""}
+              onChange={setMaxPlayers}
+            />
           </label>
         </div>
         <h3>Continuation settings</h3>

--- a/frontend/src/JoinRoom.tsx
+++ b/frontend/src/JoinRoom.tsx
@@ -3,6 +3,7 @@ import { WebsocketContext } from "./WebsocketProvider";
 import { TimerContext } from "./TimerProvider";
 import LabeledPlay from "./LabeledPlay";
 import PublicRoomsPane from "./PublicRoomsPane";
+import { AppStateContext } from "./AppStateProvider";
 
 interface IProps {
   name: string;
@@ -18,6 +19,7 @@ const JoinRoom = (props: IProps): JSX.Element => {
   );
   const { send } = React.useContext(WebsocketContext);
   const { setTimeout } = React.useContext(TimerContext);
+  const { state, updateState } = React.useContext(AppStateContext);
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>): void =>
     props.setName(event.target.value.trim());
@@ -27,6 +29,9 @@ const JoinRoom = (props: IProps): JSX.Element => {
 
   const handleSubmit = (event: React.SyntheticEvent): void => {
     event.preventDefault();
+    if (state.joinError) {
+      updateState({ joinError: null });
+    }
     if (props.name.length > 0 && props.room_name.length === 16) {
       send({
         room_name: props.room_name,
@@ -63,6 +68,9 @@ const JoinRoom = (props: IProps): JSX.Element => {
     props.setRoomName(
       Array.from(arr, (d) => ("0" + d.toString(16)).substr(-2)).join(""),
     );
+    if (state.joinError) {
+      updateState({ joinError: null });
+    }
   };
 
   if (shouldGenerate) {
@@ -108,7 +116,8 @@ const JoinRoom = (props: IProps): JSX.Element => {
             disabled={
               props.room_name.length !== 16 ||
               props.name.length === 0 ||
-              props.name.length > 32
+              props.name.length > 32 ||
+              state.joinError !== null
             }
           />
         </div>
@@ -137,7 +146,7 @@ const JoinRoom = (props: IProps): JSX.Element => {
           to you.
         </p>
       </div>
-      <PublicRoomsPane setRoomName={props.setRoomName} />
+      <PublicRoomsPane setRoomName={props.setRoomName} updateState={updateState} />
     </div>
   );
 };

--- a/frontend/src/PublicRoomsPane.tsx
+++ b/frontend/src/PublicRoomsPane.tsx
@@ -19,22 +19,25 @@ const Cell = styled.div`
 interface RowIProps {
   roomName: string;
   numPlayers: number;
-  setRoomName: (name: string, e: React.MouseEvent) => void;
+  maxPlayers: number | null;
+  setRoomName: (name: string) => void;
 }
 
 const PublicRoomRow = ({
   roomName,
   numPlayers,
+  maxPlayers,
   setRoomName,
 }: RowIProps): JSX.Element => {
+  const playersDisplay = maxPlayers ? `${numPlayers}/${maxPlayers}` : `${numPlayers}`;
   return (
     <Row>
       <Cell>
-        <button onClick={(e) => setRoomName(roomName, e)} className="normal">
+        <button onClick={() => setRoomName(roomName)} className="normal">
           {roomName}
         </button>
       </Cell>
-      <Cell>{numPlayers}</Cell>
+      <Cell>{playersDisplay}</Cell>
     </Row>
   );
 };
@@ -91,6 +94,7 @@ const PublicRoomsPane = (props: IProps): JSX.Element => {
               key={roomInfo.name}
               roomName={roomInfo.name}
               numPlayers={roomInfo.num_players}
+              maxPlayers={roomInfo.max_players}
               setRoomName={props.setRoomName}
             />
           );

--- a/frontend/src/PublicRoomsPane.tsx
+++ b/frontend/src/PublicRoomsPane.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { useEffect, useState } from "react";
 import styled from "styled-components";
+import { AppState } from "./AppStateProvider";
 
 const Row = styled.div`
   display: table-row;
@@ -44,6 +45,7 @@ const PublicRoomRow = ({
 
 interface IProps {
   setRoomName: (name: string) => void;
+  updateState: (newState: Partial<AppState>) => void;
 }
 
 const PublicRoomsPane = (props: IProps): JSX.Element => {
@@ -53,6 +55,9 @@ const PublicRoomsPane = (props: IProps): JSX.Element => {
     loadPublicRooms();
   }, []);
   const loadPublicRooms = (): void => {
+    // Clear any previous join error when refreshing
+    props.updateState({ joinError: null });
+
     try {
       const fetchAsync = async (): Promise<void> => {
         const fetchResult = await fetch("public_games.json");

--- a/frontend/src/gen-types.d.ts
+++ b/frontend/src/gen-types.d.ts
@@ -137,6 +137,9 @@ export type Action =
       SetGameVisibility: GameVisibility;
     }
   | {
+      SetMaxPlayers: number | null;
+    }
+  | {
       /**
        * @minItems 2
        * @maxItems 2
@@ -629,6 +632,11 @@ export type MessageVariant =
       tractor_requirements: TractorRequirements;
       type: "TractorRequirementsChanged";
       [k: string]: unknown;
+    }
+  | {
+      max_players: number | null;
+      type: "MaxPlayersSet";
+      [k: string]: unknown;
     };
 
 export interface _Combined {
@@ -919,6 +927,7 @@ export interface PropagatedState {
   throw_penalty?: ThrowPenalty & string;
   tractor_requirements?: TractorRequirements;
   trick_draw_policy?: TrickDrawPolicy & string;
+  max_players?: number | null;
   [k: string]: unknown;
 }
 export interface DrawPhase {

--- a/frontend/src/gen-types.schema.json
+++ b/frontend/src/gen-types.schema.json
@@ -522,6 +522,18 @@
         },
         {
           "type": "object",
+          "required": ["SetMaxPlayers"],
+          "properties": {
+            "SetMaxPlayers": {
+              "type": ["integer", "null"],
+              "format": "uint",
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
           "required": ["Bid"],
           "properties": {
             "Bid": {
@@ -993,6 +1005,11 @@
         "revealed_cards": {
           "default": 0,
           "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "max_players": {
+          "type": ["integer", "null"],
           "format": "uint",
           "minimum": 0.0
         }
@@ -2531,6 +2548,20 @@
               "enum": ["TractorRequirementsChanged"]
             }
           }
+        },
+        {
+          "required": ["max_players", "type"],
+          "properties": {
+            "max_players": {
+              "type": ["integer", "null"],
+              "format": "uint",
+              "minimum": 0.0
+            },
+            "type": {
+              "type": "string",
+              "enum": ["MaxPlayersSet"]
+            }
+          }
         }
       ]
     },
@@ -2687,6 +2718,11 @@
         },
         "trump": {
           "$ref": "#/definitions/Trump"
+        },
+        "max_players": {
+          "type": ["integer", "null"],
+          "format": "uint",
+          "minimum": 0.0
         }
       }
     },
@@ -3037,6 +3073,11 @@
               "$ref": "#/definitions/TrickDrawPolicy"
             }
           ]
+        },
+        "max_players": {
+          "type": ["integer", "null"],
+          "format": "uint",
+          "minimum": 0.0
         }
       }
     },

--- a/frontend/src/websocketHandler.ts
+++ b/frontend/src/websocketHandler.ts
@@ -52,7 +52,14 @@ const errorHandler: WebsocketHandler = (
   message: GameMessage,
 ) => {
   if ("Error" in message) {
-    return { errors: [...state.errors, message.Error] };
+    const errorMsg = message.Error;
+    const isJoinError = errorMsg.includes("Maximum number of players reached");
+    return {
+      errors: [...state.errors, errorMsg],
+      gameState: null,
+      joinError: isJoinError ? errorMsg : state.joinError,
+      connectionNonce: isJoinError ? state.connectionNonce + 1 : state.connectionNonce,
+    };
   } else {
     return null;
   }

--- a/storage/src/redis_storage.rs
+++ b/storage/src/redis_storage.rs
@@ -83,7 +83,7 @@ impl<S: State> RedisStorage<S> {
                 .cmd("INCR")
                 .arg("states_created")
                 .ignore()
-                .query_async(connection_manager)
+                .query_async::<_, ()>(connection_manager)
                 .await?;
         } else {
             redis::pipe()
@@ -92,7 +92,7 @@ impl<S: State> RedisStorage<S> {
                 .arg(key)
                 .arg(as_json)
                 .ignore()
-                .query_async(connection_manager)
+                .query_async::<_, ()>(connection_manager)
                 .await?;
         }
         Ok(())
@@ -139,14 +139,14 @@ impl<S: State> RedisStorage<S> {
     ) -> Result<R, E> {
         redis::cmd("WATCH")
             .arg(key.clone())
-            .query_async(&mut connection_manager)
+            .query_async::<_, ()>(&mut connection_manager)
             .await
             .map_err(RedisStorageError::from)?;
         let res = op.await;
         if res.is_err() {
             redis::cmd("UNWATCH")
                 .arg(key)
-                .query_async(&mut connection_manager)
+                .query_async::<_, ()>(&mut connection_manager)
                 .await
                 .map_err(RedisStorageError::from)?;
         }


### PR DESCRIPTION
Thanks for making shengji on web - I've spent countless hours on this site :-)

Closes #424

**Summary:**

This pull request implements a new game setting that allows the host to set a maximum player limit for a game room. It also addresses several bugs related to the player joining process, particularly when a game lobby is full.

**Changes:**

1.  **Max Players Feature:**
    *   Introduced a `max_players` option within the game's configuration (`core/src/settings.rs`).
    *   Added backend support (actions, messages) for setting and propagating this limit.
    *   Integrated a UI element in the game settings screen (`frontend/src/Initialize.tsx`) for hosts to adjust the limit.
    *   Updated the public games list (`frontend/src/PublicRoomsPane.tsx`) to display both the current number of players and the maximum limit, if set (e.g., "5/8"). The backend API (`backend/src/state_dump.rs`) was updated accordingly.

2.  **Limit Enforcement:**
    *   Modified the backend logic (`add_player`, `make_player` in `core/src/settings.rs`) to prevent players or observers from joining if the `max_players` limit has been reached.

3.  **Bug Fixes:**
    *   **Incorrect Error on Full Game Join:** Resolved an issue where trying to join a game at maximum capacity incorrectly resulted in a generic connection error message after a delay. The fix ensures the specific "Maximum number of players reached" error is displayed promptly to the user. This involved adjustments to backend error handling and connection management (`backend/src/shengji_handler.rs`, `backend/src/utils.rs`).
    *   **Unexpected Spectator Join:** Corrected a bug where a user who failed to join a full game might later be automatically added as a spectator if the game's capacity was increased. The solution involves ensuring game state updates are targeted correctly after actions and refining frontend state management (`backend/src/utils.rs`, `frontend/src/websocketHandler.ts`).
    *   **Join Button State Management:** Addressed an issue where the "Join" button could remain disabled after a failed join attempt, even after the user refreshed the public games list. The button state is now correctly updated when the user indicates intent to retry (`frontend/src/PublicRoomsPane.tsx`, `frontend/src/JoinRoom.tsx`).

4.  **Code Maintenance:**
    *   Addressed compiler warnings related to Redis query return types in `storage/src/redis_storage.rs` by specifying explicit types, improving future compatibility.

**Testing:**

Manual testing was performed throughout development to verify:
*   The max players setting can be configured and is displayed correctly.
*   Joining a full game displays the correct error and prevents entry.
*   Joining a game after the limit is increased works as expected.
*   The join button state updates correctly after failed attempts and refreshes.
*   The automatic spectator join issue is resolved.