### PR TITLE
Add configurable CORS support for /api/rpc endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ listens on 127.0.0.1:3030, and should only be exposed to an external network
 behind a proxy that supports both HTTP and WebSocket protocols (only tested
 with `nginx`).
 
+## Environment Variables
+
+- `CORS_ALLOWED_ORIGINS`: Comma-separated list of allowed origins for CORS requests to the `/api/rpc` endpoint (e.g., `"https://example.com,https://app.example.com"`). Set to `"*"` to allow any origin (not recommended for production). If not set, defaults to allowing common localhost origins for development (`http://localhost:3000,http://localhost:3030,http://127.0.0.1:3000,http://127.0.0.1:3030`).
+
 # Development
 
 ```

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
 default = []
-dynamic = ["slog-term", "tower-http"]
+dynamic = ["slog-term"]
 
 [dependencies]
 anyhow = "1.0"
@@ -39,7 +39,7 @@ tokio = { version = "1.28", features = [
     "sync",
     "io-util",
 ] }
-tower-http = { version = "0.4", features = ["fs"], optional = true }
+tower-http = { version = "0.4", features = ["fs", "cors"] }
 zstd = "0.12"
 
 [dev-dependencies]

--- a/mechanics/src/hands.rs
+++ b/mechanics/src/hands.rs
@@ -50,7 +50,7 @@ impl<'de> Deserialize<'de> for Hands {
         if let serde_json::Value::Object(obj) = helper.hands {
             for (key, value) in obj {
                 let player_id = PlayerID::from_str(&key)
-                    .map_err(|_| de::Error::custom(format!("invalid PlayerID: {}", key)))?;
+                    .map_err(|_| de::Error::custom(format!("invalid PlayerID: {key}")))?;
                 let card_map: HashMap<Card, usize> =
                     serde_json::from_value(value).map_err(de::Error::custom)?;
                 hands_map.insert(player_id, card_map);


### PR DESCRIPTION
- Add tower-http with cors feature as a regular dependency
- Configure CORS origins via CORS_ALLOWED_ORIGINS environment variable
- Support comma-separated list of origins or "*" for any origin
- Default to common localhost origins for development
- Fix clippy warning about uninlined format args
- Document new environment variable in README

This enables cross-origin requests to /api/rpc when WEBSOCKET_HOST is configured to a different origin, while maintaining security by requiring explicit origin configuration in production.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>

:house: Remote-Dev: homespace