### PR TITLE
Fix longer-tuple bypass and leader bomb tracking in trick validation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,8 +128,15 @@ The project maintains type safety between Rust and TypeScript by:
 - Component testing for React UI elements
 - Manual testing for WebSocket interactions and gameplay flow
 
-### Before committing frontend changes:
-Always run lints and formatting before committing any frontend (`.tsx`/`.ts`) changes:
+### Before committing any changes:
+Always run lints and formatting before committing:
+
+**Rust:**
+```bash
+cargo fmt --all && cargo clippy
+```
+
+**Frontend (`.tsx`/`.ts`):**
 ```bash
 cd frontend && yarn lint --fix && yarn prettier --write
 ```

--- a/mechanics/src/trick.rs
+++ b/mechanics/src/trick.rs
@@ -318,40 +318,19 @@ impl TrickFormat {
             // (e.g. a pair) by decomposing — short-circuiting before hand_can_play
             // detects that a genuine shorter tuple was available in the hand.
             //
-            // Guard (bombs-enabled only): if the hand contains a genuine N-tuple
-            // (N >= 2) of a same-suit card that is underrepresented in the play,
-            // AND the play contains some card with count > N (a longer tuple that
-            // could be filling the N-slot), the play is illegal — the genuine
-            // shorter tuple must be used instead.
+            // For each requirement, after play_matches fires, we check whether the
+            // hand has enough genuine N-tuples (hand_ct == N, not in play) to fill
+            // ALL N-slots in that requirement. If so, and the play contains a card
+            // with count > N, the play is illegal — the genuine shorter tuples must
+            // be used for those slots.
             //
-            // The bombs-enabled restriction matters: without it, a NoBombs quad
-            // (count=4) used for two pair slots would incorrectly fire the guard
-            // even when it legitimately fills both slots. When bombs are active,
-            // a quad is a bomb (separate mechanic), so count=3 (triple) is the
-            // longest non-bomb tuple and the guard applies correctly.
+            // Counting against n_slots_needed (not just "any genuine tuple") avoids
+            // a false positive when the hand has fewer genuine tuples than slots: e.g.
+            // hand=[S_2×4, S_5×2] playing S_2×4 for [2 pair slots] — only 1 genuine
+            // pair exists but 2 are needed, so the quad legitimately fills both.
             let play_counts = OrderedCard::make_map(proposed.iter().copied(), self.trump);
-            let longer_tuple_bypasses_genuine_tuple = bomb_policy.bombs_enabled()
-                && matches!(
-                    trick_draw_policy,
-                    TrickDrawPolicy::LongerTuplesProtected
-                        | TrickDrawPolicy::LongerTuplesProtectedAndOnlyDrawTractorOnTractor
-                )
-                && hand.iter().any(|(c, &hand_ct)| {
-                    hand_ct >= 2
-                        && self.trump.effective_suit(*c) == self.suit
-                        && play_counts
-                            .get(&OrderedCard {
-                                card: *c,
-                                trump: self.trump,
-                            })
-                            .map(|&ct| ct < hand_ct)
-                            .unwrap_or(true)
-                        && play_counts.values().any(|&play_ct| play_ct > hand_ct)
-                });
 
             for requirement in self.decomposition(trick_draw_policy) {
-                // If it's a match, we're good — unless the play is using a longer
-                // tuple to fill a slot that a genuine shorter tuple in hand could fill.
                 let play_matches = UnitLike::check_play(
                     play_counts.clone(),
                     requirement.iter().cloned(),
@@ -361,7 +340,45 @@ impl TrickFormat {
                 .is_some();
 
                 if play_matches {
-                    if longer_tuple_bypasses_genuine_tuple {
+                    // Guard: for each distinct simple N-tuple slot (N >= 2) in this
+                    // requirement, check if the hand has enough genuine N-tuples to
+                    // fill all such slots while the play uses a longer tuple instead.
+                    let longer_tuple_bypasses_genuine = matches!(
+                        trick_draw_policy,
+                        TrickDrawPolicy::LongerTuplesProtected
+                            | TrickDrawPolicy::LongerTuplesProtectedAndOnlyDrawTractorOnTractor
+                    ) && requirement
+                        .iter()
+                        .filter(|u| u.adjacent_tuples.len() == 1)
+                        .any(|u| {
+                            let n = u.adjacent_tuples[0];
+                            if n < 2 {
+                                return false;
+                            }
+                            let n_slots_needed = requirement
+                                .iter()
+                                .filter(|u2| {
+                                    u2.adjacent_tuples.len() == 1 && u2.adjacent_tuples[0] == n
+                                })
+                                .count();
+                            let genuine_in_hand = hand
+                                .iter()
+                                .filter(|(c, &hand_ct)| {
+                                    hand_ct == n
+                                        && self.trump.effective_suit(**c) == self.suit
+                                        && play_counts
+                                            .get(&OrderedCard {
+                                                card: **c,
+                                                trump: self.trump,
+                                            })
+                                            .map(|&ct| ct < n)
+                                            .unwrap_or(true)
+                                })
+                                .count();
+                            genuine_in_hand >= n_slots_needed
+                                && play_counts.values().any(|&play_ct| play_ct > n)
+                        });
+                    if longer_tuple_bypasses_genuine {
                         return false;
                     }
                     return true;
@@ -3037,6 +3054,98 @@ mod tests {
             ),
             "playing triple + singles should be legal when no genuine pair is available"
         );
+    }
+
+    /// The longer-tuple guard must count how many N-slots the current requirement has and
+    /// compare that to how many genuine N-tuples (hand_ct == N) the hand can provide.
+    /// Only fire when genuine_in_hand >= n_slots_needed.
+    ///
+    /// Example: [2 pair slots] with only 1 genuine pair in hand → quad filling both slots
+    /// is LEGAL (not enough genuine pairs for both slots).
+    ///
+    /// Example: [1 pair + 1 single] (decomposition) with 1 genuine pair in hand → playing
+    /// the full triple (3 copies, filling pair+single) is ILLEGAL; the genuine pair must
+    /// fill the pair slot.
+    #[test]
+    fn test_longer_tuple_guard_requires_enough_genuine_tuples() {
+        // Tractor format (2 pair slots, 4 cards).
+        let tf_tractor = TrickFormat {
+            suit: EffectiveSuit::Trump,
+            trump: TRUMP,
+            units: vec![TrickUnit::Tractor {
+                count: 2,
+                members: vec![oc!(S_2), oc!(S_3)],
+            }],
+        };
+        // [1 pair + 1 single] format (3 cards).
+        let tf_pair_single = TrickFormat {
+            suit: EffectiveSuit::Trump,
+            trump: TRUMP,
+            units: vec![
+                TrickUnit::Repeated {
+                    count: 2,
+                    card: oc!(S_3),
+                },
+                TrickUnit::Repeated {
+                    count: 1,
+                    card: oc!(S_5),
+                },
+            ],
+        };
+
+        for bp in [BombPolicy::NoBombs, BombPolicy::AllowBombs] {
+            // === Tractor (2 pair slots) ===
+            // Only 1 genuine pair (S_5×2) in hand; 2 pair slots needed.
+            // S_2×4 legitimately fills both → LEGAL (guard should not fire).
+            let hand = Card::count(vec![S_2, S_2, S_2, S_2, S_3, S_5, S_5]);
+            assert!(
+                tf_tractor.is_legal_play(
+                    &hand,
+                    &[S_2, S_2, S_2, S_2],
+                    TrickDrawPolicy::LongerTuplesProtected,
+                    bp,
+                ),
+                "quad filling 2-slot tractor is legal when only 1 genuine pair exists (bp={bp:?})"
+            );
+
+            // === [1 pair + 1 single] decomposition ===
+            // Hand has S_2×3 (triple) + S_5×2 (genuine pair). Playing the full triple
+            // ([S_2,S_2,S_2] → pair+single via NoProtections) should be ILLEGAL:
+            // 1 genuine pair is available for the 1 pair slot.
+            let hand_with_pair = Card::count(vec![S_2, S_2, S_2, S_5, S_5, S_6]);
+            assert!(
+                !tf_pair_single.is_legal_play(
+                    &hand_with_pair,
+                    &[S_2, S_2, S_2],
+                    TrickDrawPolicy::LongerTuplesProtected,
+                    bp,
+                ),
+                "triple filling pair+single when genuine pair available should be ILLEGAL (bp={bp:?})"
+            );
+
+            // Playing [S_5,S_5,S_2] (genuine pair + single) is LEGAL.
+            assert!(
+                tf_pair_single.is_legal_play(
+                    &hand_with_pair,
+                    &[S_5, S_5, S_2],
+                    TrickDrawPolicy::LongerTuplesProtected,
+                    bp,
+                ),
+                "genuine pair + single is LEGAL (bp={bp:?})"
+            );
+
+            // With no genuine pair (only triple), [S_2,S_2,S_2] is LEGAL.
+            let hand_no_pair = Card::count(vec![S_2, S_2, S_2, S_6, S_7, S_8]);
+            assert!(
+                tf_pair_single.is_legal_play(
+                    &hand_no_pair,
+                    &[S_2, S_2, S_2],
+                    TrickDrawPolicy::LongerTuplesProtected,
+                    bp,
+                ),
+                "triple filling pair+single is LEGAL when no genuine pair exists (bp={bp:?})"
+            );
+        }
     }
 
     /// Bug: when the leader plays a bomb, compute_winner didn't track it as a bomb

--- a/mechanics/src/trick.rs
+++ b/mechanics/src/trick.rs
@@ -318,16 +318,15 @@ impl TrickFormat {
             // (e.g. a pair) by decomposing — short-circuiting before hand_can_play
             // detects that a genuine shorter tuple was available in the hand.
             //
-            // For each requirement, after play_matches fires, we check whether the
-            // hand has enough genuine N-tuples (hand_ct == N, not in play) to fill
-            // ALL N-slots in that requirement. If so, and the play contains a card
-            // with count > N, the play is illegal — the genuine shorter tuples must
-            // be used for those slots.
+            // For each requirement, after play_matches fires, for each simple N-slot
+            // (N >= 2) we compute how many such slots are NOT already covered by
+            // play cards with play_ct == N. We then ask: can the hand satisfy those
+            // remaining N-slots under the protection policy? If yes, the play is
+            // illegally using longer tuples where genuine shorter tuples were available.
             //
-            // Counting against n_slots_needed (not just "any genuine tuple") avoids
-            // a false positive when the hand has fewer genuine tuples than slots: e.g.
-            // hand=[S_2×4, S_5×2] playing S_2×4 for [2 pair slots] — only 1 genuine
-            // pair exists but 2 are needed, so the quad legitimately fills both.
+            // Using check_play on the remaining slots (rather than counting hand_ct==N
+            // cards manually) means the same protection semantics apply: a triple in
+            // hand can't be forced into a pair slot, so it won't count.
             let play_counts = OrderedCard::make_map(proposed.iter().copied(), self.trump);
 
             for requirement in self.decomposition(trick_draw_policy) {
@@ -340,9 +339,6 @@ impl TrickFormat {
                 .is_some();
 
                 if play_matches {
-                    // Guard: for each distinct simple N-tuple slot (N >= 2) in this
-                    // requirement, check if the hand has enough genuine N-tuples to
-                    // fill all such slots while the play uses a longer tuple instead.
                     let longer_tuple_bypasses_genuine = matches!(
                         trick_draw_policy,
                         TrickDrawPolicy::LongerTuplesProtected
@@ -355,28 +351,39 @@ impl TrickFormat {
                             if n < 2 {
                                 return false;
                             }
-                            let n_slots_needed = requirement
+                            // N-slots in this requirement
+                            let n_slots = requirement
                                 .iter()
                                 .filter(|u2| {
                                     u2.adjacent_tuples.len() == 1 && u2.adjacent_tuples[0] == n
                                 })
                                 .count();
-                            let genuine_in_hand = hand
+                            // N-slots already covered by play cards with play_ct == n
+                            // (these cards are legitimately filling the N-slot)
+                            let covered_by_play = play_counts
                                 .iter()
-                                .filter(|(c, &hand_ct)| {
-                                    hand_ct == n
-                                        && self.trump.effective_suit(**c) == self.suit
-                                        && play_counts
-                                            .get(&OrderedCard {
-                                                card: **c,
-                                                trump: self.trump,
-                                            })
-                                            .map(|&ct| ct < n)
-                                            .unwrap_or(true)
+                                .filter(|(oc, &pct)| {
+                                    pct == n && self.trump.effective_suit(oc.card) == self.suit
                                 })
                                 .count();
-                            genuine_in_hand >= n_slots_needed
-                                && play_counts.values().any(|&play_ct| play_ct > n)
+                            let remaining = n_slots.saturating_sub(covered_by_play);
+                            if remaining == 0 {
+                                return false;
+                            }
+                            // Can the hand fill the remaining N-slots?
+                            let remaining_units: Vec<UnitLike> =
+                                std::iter::repeat_with(|| UnitLike {
+                                    adjacent_tuples: vec![n],
+                                })
+                                .take(remaining)
+                                .collect();
+                            UnitLike::check_play(
+                                OrderedCard::make_map(available_cards.iter().copied(), self.trump),
+                                remaining_units.into_iter(),
+                                trick_draw_policy,
+                            )
+                            .next()
+                            .is_some()
                         });
                     if longer_tuple_bypasses_genuine {
                         return false;

--- a/mechanics/src/trick.rs
+++ b/mechanics/src/trick.rs
@@ -313,37 +313,35 @@ impl TrickFormat {
             // We achieve this by excluding bomb cards from the available-cards set used
             // for the "can the hand do better?" check, and using NoProtections for the
             // remaining cards so the check is not artificially suppressed.
-            let (available_cards, hand_check_policy): (Vec<Card>, TrickDrawPolicy) =
-                if bomb_policy.bombs_enabled()
-                    && matches!(
-                        trick_draw_policy,
-                        TrickDrawPolicy::LongerTuplesProtected
-                            | TrickDrawPolicy::LongerTuplesProtectedAndOnlyDrawTractorOnTractor
-                    )
-                {
-                    let bomb_free = Card::cards(
-                        hand.iter().filter(|(c, ct)| {
-                            self.trump.effective_suit(**c) == self.suit && **ct < 4
-                        }),
-                    )
-                    .copied()
-                    .collect::<Vec<_>>();
-                    let policy = match trick_draw_policy {
-                        TrickDrawPolicy::LongerTuplesProtectedAndOnlyDrawTractorOnTractor => {
-                            TrickDrawPolicy::OnlyDrawTractorOnTractor
-                        }
-                        _ => TrickDrawPolicy::NoProtections,
-                    };
-                    (bomb_free, policy)
-                } else {
-                    let cards = Card::cards(
-                        hand.iter()
-                            .filter(|(c, _)| self.trump.effective_suit(**c) == self.suit),
-                    )
-                    .copied()
-                    .collect::<Vec<_>>();
-                    (cards, trick_draw_policy)
+            let (available_cards, hand_check_policy): (Vec<Card>, TrickDrawPolicy) = if bomb_policy
+                .bombs_enabled()
+                && matches!(
+                    trick_draw_policy,
+                    TrickDrawPolicy::LongerTuplesProtected
+                        | TrickDrawPolicy::LongerTuplesProtectedAndOnlyDrawTractorOnTractor
+                ) {
+                let bomb_free = Card::cards(
+                    hand.iter()
+                        .filter(|(c, ct)| self.trump.effective_suit(**c) == self.suit && **ct < 4),
+                )
+                .copied()
+                .collect::<Vec<_>>();
+                let policy = match trick_draw_policy {
+                    TrickDrawPolicy::LongerTuplesProtectedAndOnlyDrawTractorOnTractor => {
+                        TrickDrawPolicy::OnlyDrawTractorOnTractor
+                    }
+                    _ => TrickDrawPolicy::NoProtections,
                 };
+                (bomb_free, policy)
+            } else {
+                let cards = Card::cards(
+                    hand.iter()
+                        .filter(|(c, _)| self.trump.effective_suit(**c) == self.suit),
+                )
+                .copied()
+                .collect::<Vec<_>>();
+                (cards, trick_draw_policy)
+            };
 
             for requirement in self.decomposition(trick_draw_policy) {
                 // If it's a match, we're good!
@@ -830,6 +828,29 @@ impl Trick {
     }
 
     fn _defeats(m: &Units, winner: &Units, throw_eval_policy: ThrowEvaluationPolicy) -> bool {
+        let m_is_bomb = m.len() == 1 && m[0].is_bomb();
+        let w_is_bomb = winner.len() == 1 && winner[0].is_bomb();
+
+        if m_is_bomb || w_is_bomb {
+            if !m_is_bomb {
+                return false; // non-bomb never beats a bomb
+            }
+            if !w_is_bomb {
+                return true; // bomb always beats a non-bomb
+            }
+            // Both are bombs: more cards wins; equal size: higher rank wins
+            // (cmp_effective handles trump > non-trump).
+            let m_size = m[0].size();
+            let w_size = winner[0].size();
+            return match m_size.cmp(&w_size) {
+                Ordering::Greater => true,
+                Ordering::Less => false,
+                Ordering::Equal => {
+                    m[0].first_card().cmp_effective(winner[0].first_card()) == Ordering::Greater
+                }
+            };
+        }
+
         match throw_eval_policy {
             ThrowEvaluationPolicy::All => m
                 .iter()
@@ -876,11 +897,7 @@ impl Trick {
 
     fn compute_winner(&self, throw_eval_policy: ThrowEvaluationPolicy) -> Option<PlayerID> {
         let tf = self.trick_format.as_ref()?;
-        let mut winner = (0, tf.units.to_vec());
-        // The leader's play is a bomb when the trick format is a single bomb unit.
-        // We must track this so that a subsequent lower bomb does not incorrectly
-        // win via the "bomb beats non-bomb" branch.
-        let mut winner_is_bomb = tf.units.len() == 1 && tf.units[0].is_bomb();
+        let mut winner = (0usize, tf.units.to_vec());
 
         for (idx, _pc) in self.played_cards.iter().enumerate().skip(1) {
             let mapping = self.played_card_mappings.get(idx).and_then(|m| m.as_ref());
@@ -888,34 +905,12 @@ impl Trick {
 
             if this_is_bomb {
                 let mapping = mapping.unwrap();
-                let dominated = if winner_is_bomb {
-                    // Both are bombs: more cards wins; equal size: higher rank wins
-                    // (cmp_effective handles trump > non-trump).
-                    let cur_size = mapping[0].size();
-                    let win_size = winner.1[0].size();
-                    match cur_size.cmp(&win_size) {
-                        Ordering::Greater => true,
-                        Ordering::Less => false,
-                        Ordering::Equal => {
-                            mapping[0]
-                                .first_card()
-                                .cmp_effective(winner.1[0].first_card())
-                                == Ordering::Greater
-                        }
-                    }
-                } else {
-                    true // Bomb always beats non-bomb
-                };
-                if dominated {
+                if Self::_defeats(mapping, &winner.1, throw_eval_policy) {
                     winner = (idx, mapping.clone());
-                    winner_is_bomb = true;
                 }
-            } else if !winner_is_bomb {
-                if let Ok(mut mm) = tf.matches(&self.played_cards[idx].cards) {
-                    let greater = mm.find(|m| Self::_defeats(m, &winner.1, throw_eval_policy));
-                    if let Some(m) = greater {
-                        winner = (idx, m);
-                    }
+            } else if let Ok(mut mm) = tf.matches(&self.played_cards[idx].cards) {
+                if let Some(m) = mm.find(|m| Self::_defeats(m, &winner.1, throw_eval_policy)) {
+                    winner = (idx, m);
                 }
             }
         }
@@ -3075,17 +3070,11 @@ mod tests {
         let bp = BombPolicy::AllowBombs;
         let mut hands = Hands::new(vec![P1, P2, P3, P4]);
         // P1 leads with a 6-card bomb (6 heart 2s)
-        hands
-            .add(P1, vec![H_2, H_2, H_2, H_2, H_2, H_2])
-            .unwrap();
+        hands.add(P1, vec![H_2, H_2, H_2, H_2, H_2, H_2]).unwrap();
         // P2 plays a 6-card bomb of higher rank (6 heart jacks)
-        hands
-            .add(P2, vec![H_J, H_J, H_J, H_J, H_J, H_J])
-            .unwrap();
+        hands.add(P2, vec![H_J, H_J, H_J, H_J, H_J, H_J]).unwrap();
         // P3 plays a lower-rank 6-card bomb (6 heart 3s) after P2's win
-        hands
-            .add(P3, vec![H_3, H_3, H_3, H_3, H_3, H_3])
-            .unwrap();
+        hands.add(P3, vec![H_3, H_3, H_3, H_3, H_3, H_3]).unwrap();
         hands.add(P4, vec![C_5, C_6, C_7, C_8, C_9, C_10]).unwrap();
 
         let mut trick = Trick::new(TRUMP, vec![P1, P2, P3, P4], bp);

--- a/mechanics/src/trick.rs
+++ b/mechanics/src/trick.rs
@@ -321,12 +321,13 @@ impl TrickFormat {
             // For each requirement, after play_matches fires, for each simple N-slot
             // (N >= 2) we compute how many such slots are NOT already covered by
             // play cards with play_ct == N. We then ask: can the hand satisfy those
-            // remaining N-slots under the protection policy? If yes, the play is
-            // illegally using longer tuples where genuine shorter tuples were available.
+            // remaining N-slots under the protection policy? If yes, the player
+            // had genuine shorter tuples available and is not required to break a
+            // longer tuple to fill those slots — so the play must use them instead.
             //
             // Using check_play on the remaining slots (rather than counting hand_ct==N
-            // cards manually) means the same protection semantics apply: a triple in
-            // hand can't be forced into a pair slot, so it won't count.
+            // cards manually) means the same protection semantics apply: a longer
+            // tuple in hand can't be forced into a shorter slot, so it won't count.
             let play_counts = OrderedCard::make_map(proposed.iter().copied(), self.trump);
 
             for requirement in self.decomposition(trick_draw_policy) {

--- a/mechanics/src/trick.rs
+++ b/mechanics/src/trick.rs
@@ -313,46 +313,47 @@ impl TrickFormat {
             .copied()
             .collect::<Vec<_>>();
 
-            // When bombs are enabled and LongerTuplesProtected is active we need
-            // an extra guard. The play_matches check below uses NoProtections, which
-            // lets a triple played intact (e.g. H_2×3) satisfy a pair slot (as
-            // pair+single). This short-circuits before hand_can_play runs, so a
-            // genuine pair like KK can be silently bypassed.
+            // With LongerTuplesProtected, play_matches uses NoProtections, so a
+            // longer tuple in the play (e.g. a triple) can satisfy a shorter slot
+            // (e.g. a pair) by decomposing — short-circuiting before hand_can_play
+            // detects that a genuine shorter tuple was available in the hand.
             //
-            // Guard: if the play contains any card with count ≥ 3 (a triple played
-            // as three cards) AND the hand contains a genuine pair (count == 2) of a
-            // same-suit card that is NOT present in the play, the play is illegal —
-            // the genuine pair must be included. Bombs (count ≥ 4) are already
-            // excluded from pair-matching by LongerTuplesProtected in hand_can_play,
-            // so only triples (count == 3) need this check.
-            let triple_blocks_genuine_pair = if bomb_policy.bombs_enabled()
+            // Guard (bombs-enabled only): if the hand contains a genuine N-tuple
+            // (N >= 2) of a same-suit card that is underrepresented in the play,
+            // AND the play contains some card with count > N (a longer tuple that
+            // could be filling the N-slot), the play is illegal — the genuine
+            // shorter tuple must be used instead.
+            //
+            // The bombs-enabled restriction matters: without it, a NoBombs quad
+            // (count=4) used for two pair slots would incorrectly fire the guard
+            // even when it legitimately fills both slots. When bombs are active,
+            // a quad is a bomb (separate mechanic), so count=3 (triple) is the
+            // longest non-bomb tuple and the guard applies correctly.
+            let play_counts = OrderedCard::make_map(proposed.iter().copied(), self.trump);
+            let longer_tuple_bypasses_genuine_tuple = bomb_policy.bombs_enabled()
                 && matches!(
                     trick_draw_policy,
                     TrickDrawPolicy::LongerTuplesProtected
                         | TrickDrawPolicy::LongerTuplesProtectedAndOnlyDrawTractorOnTractor
-                ) {
-                let play_counts = OrderedCard::make_map(proposed.iter().copied(), self.trump);
-                play_counts.values().any(|&ct| ct >= 3)
-                    && hand.iter().any(|(c, &hand_ct)| {
-                        hand_ct == 2
-                            && self.trump.effective_suit(*c) == self.suit
-                            && play_counts
-                                .get(&OrderedCard {
-                                    card: *c,
-                                    trump: self.trump,
-                                })
-                                .map(|&ct| ct < 2)
-                                .unwrap_or(true)
-                    })
-            } else {
-                false
-            };
+                )
+                && hand.iter().any(|(c, &hand_ct)| {
+                    hand_ct >= 2
+                        && self.trump.effective_suit(*c) == self.suit
+                        && play_counts
+                            .get(&OrderedCard {
+                                card: *c,
+                                trump: self.trump,
+                            })
+                            .map(|&ct| ct < hand_ct)
+                            .unwrap_or(true)
+                        && play_counts.values().any(|&play_ct| play_ct > hand_ct)
+                });
 
             for requirement in self.decomposition(trick_draw_policy) {
-                // If it's a match, we're good — unless the play contains a triple
-                // that is substituting for a genuine pair that was left unplayed.
+                // If it's a match, we're good — unless the play is using a longer
+                // tuple to fill a slot that a genuine shorter tuple in hand could fill.
                 let play_matches = UnitLike::check_play(
-                    OrderedCard::make_map(proposed.iter().copied(), self.trump),
+                    play_counts.clone(),
                     requirement.iter().cloned(),
                     TrickDrawPolicy::NoProtections,
                 )
@@ -360,7 +361,7 @@ impl TrickFormat {
                 .is_some();
 
                 if play_matches {
-                    if triple_blocks_genuine_pair {
+                    if longer_tuple_bypasses_genuine_tuple {
                         return false;
                     }
                     return true;

--- a/mechanics/src/trick.rs
+++ b/mechanics/src/trick.rs
@@ -306,45 +306,51 @@ impl TrickFormat {
                 return true;
             }
 
-            // When bombs are enabled and LongerTuplesProtected is active, only actual
-            // bombs (count >= 4) should be shielded from format-following obligations.
-            // Non-bomb tuples like 3-of-a-kind are not bombs and must contribute to
-            // satisfying the format (e.g., a triple must yield a pair when one is needed).
-            // We achieve this by excluding bomb cards from the available-cards set used
-            // for the "can the hand do better?" check, and using NoProtections for the
-            // remaining cards so the check is not artificially suppressed.
-            let (available_cards, hand_check_policy): (Vec<Card>, TrickDrawPolicy) = if bomb_policy
-                .bombs_enabled()
+            let available_cards = Card::cards(
+                hand.iter()
+                    .filter(|(c, _)| self.trump.effective_suit(**c) == self.suit),
+            )
+            .copied()
+            .collect::<Vec<_>>();
+
+            // When bombs are enabled and LongerTuplesProtected is active we need
+            // an extra guard. The play_matches check below uses NoProtections, which
+            // lets a triple played intact (e.g. H_2×3) satisfy a pair slot (as
+            // pair+single). This short-circuits before hand_can_play runs, so a
+            // genuine pair like KK can be silently bypassed.
+            //
+            // Guard: if the play contains any card with count ≥ 3 (a triple played
+            // as three cards) AND the hand contains a genuine pair (count == 2) of a
+            // same-suit card that is NOT present in the play, the play is illegal —
+            // the genuine pair must be included. Bombs (count ≥ 4) are already
+            // excluded from pair-matching by LongerTuplesProtected in hand_can_play,
+            // so only triples (count == 3) need this check.
+            let triple_blocks_genuine_pair = if bomb_policy.bombs_enabled()
                 && matches!(
                     trick_draw_policy,
                     TrickDrawPolicy::LongerTuplesProtected
                         | TrickDrawPolicy::LongerTuplesProtectedAndOnlyDrawTractorOnTractor
                 ) {
-                let bomb_free = Card::cards(
-                    hand.iter()
-                        .filter(|(c, ct)| self.trump.effective_suit(**c) == self.suit && **ct < 4),
-                )
-                .copied()
-                .collect::<Vec<_>>();
-                let policy = match trick_draw_policy {
-                    TrickDrawPolicy::LongerTuplesProtectedAndOnlyDrawTractorOnTractor => {
-                        TrickDrawPolicy::OnlyDrawTractorOnTractor
-                    }
-                    _ => TrickDrawPolicy::NoProtections,
-                };
-                (bomb_free, policy)
+                let play_counts = OrderedCard::make_map(proposed.iter().copied(), self.trump);
+                play_counts.values().any(|&ct| ct >= 3)
+                    && hand.iter().any(|(c, &hand_ct)| {
+                        hand_ct == 2
+                            && self.trump.effective_suit(*c) == self.suit
+                            && play_counts
+                                .get(&OrderedCard {
+                                    card: *c,
+                                    trump: self.trump,
+                                })
+                                .map(|&ct| ct < 2)
+                                .unwrap_or(true)
+                    })
             } else {
-                let cards = Card::cards(
-                    hand.iter()
-                        .filter(|(c, _)| self.trump.effective_suit(**c) == self.suit),
-                )
-                .copied()
-                .collect::<Vec<_>>();
-                (cards, trick_draw_policy)
+                false
             };
 
             for requirement in self.decomposition(trick_draw_policy) {
-                // If it's a match, we're good!
+                // If it's a match, we're good — unless the play contains a triple
+                // that is substituting for a genuine pair that was left unplayed.
                 let play_matches = UnitLike::check_play(
                     OrderedCard::make_map(proposed.iter().copied(), self.trump),
                     requirement.iter().cloned(),
@@ -354,13 +360,16 @@ impl TrickFormat {
                 .is_some();
 
                 if play_matches {
+                    if triple_blocks_genuine_pair {
+                        return false;
+                    }
                     return true;
                 }
                 // Otherwise, if it could match in the player's hand, it's not OK.
                 let hand_can_play = UnitLike::check_play(
                     OrderedCard::make_map(available_cards.iter().copied(), self.trump),
                     requirement.iter().cloned(),
-                    hand_check_policy,
+                    trick_draw_policy,
                 )
                 .next()
                 .is_some();
@@ -2952,11 +2961,21 @@ mod tests {
 
     // ---- Bug regression tests ----
 
-    /// Bug: with LongerTuplesProtected and 4-of-a-kind bombs enabled, a 3-of-a-kind
-    /// was incorrectly treated as a protected tuple. A triple is not a bomb and
-    /// should be splittable into a pair when following a pairs-based format.
+    /// Bug: with LongerTuplesProtected and 4-of-a-kind bombs enabled, playing a triple
+    /// (count=3) as three card slots was incorrectly accepted when a genuine pair was
+    /// available in the hand.
+    ///
+    /// LongerTuplesProtected correctly protects a triple in the *hand* from being forced
+    /// to contribute a pair. However, the play-matches check was using NoProtections, so
+    /// playing three identical cards could "satisfy" a pair requirement (as pair+single),
+    /// short-circuiting before the hand check ran. This allowed the player to bypass a
+    /// genuine pair (e.g. KK) by sinking the triple into the play as three singles.
+    ///
+    /// The fix: when bombs are enabled + LongerTuplesProtected, also apply
+    /// LongerTuplesProtected to the play-matches check. A triple *in the play* (count=3)
+    /// cannot satisfy a pair requirement; two genuine copies in the play (count=2) can.
     #[test]
-    fn test_longer_tuples_protected_does_not_protect_non_bomb_triple() {
+    fn test_triple_in_play_does_not_satisfy_pair_when_genuine_pair_available() {
         let bp = BombPolicy::AllowBombs;
 
         // Trick format: 3-pair tractor in hearts (H_10-H_10-H_J-H_J-H_Q-H_Q)
@@ -2968,16 +2987,16 @@ mod tests {
         )
         .unwrap();
 
-        // Player has H_K×2 (pair), H_2×3 (triple, NOT a bomb), H_5/H_6/H_7/H_8 (singles)
+        // Player has H_K×2 (genuine pair) and H_2×3 (triple, protected by LongerTuplesProtected)
         let mut hands = Hands::new(vec![P2]);
         hands
             .add(P2, vec![H_K, H_K, H_2, H_2, H_2, H_5, H_6, H_7, H_8])
             .unwrap();
         let hand = hands.get(P2).unwrap().clone();
 
-        // Playing H_2×3 + H_5+H_6+H_7 (= "222 + 3 singles") should be ILLEGAL.
-        // The player has KK (pair) and can form 22 (pair from triple), so they must
-        // play at least 2 pairs (e.g., 22KK + 2 singles).
+        // Playing H_2×3 + H_5+H_6+H_7 (triple + 3 singles, no KK) should be ILLEGAL.
+        // The triple in the play cannot satisfy the pair requirement (count=3>2 is
+        // protected). KK is a genuine pair and hand_can_play detects it → illegal.
         assert!(
             !trick_format.is_legal_play(
                 &hand,
@@ -2985,10 +3004,11 @@ mod tests {
                 TrickDrawPolicy::LongerTuplesProtected,
                 bp,
             ),
-            "playing 3-of-a-kind + singles should be illegal when 2 pairs are available"
+            "playing triple + singles should be illegal when a genuine pair (KK) is available"
         );
 
-        // Playing H_2×2 + H_K×2 + H_5+H_6 (= "22KK56", 2 pairs + 2 singles) should be LEGAL.
+        // Playing H_2×2 + H_K×2 + H_5+H_6 (2 pairs + 2 singles) should be LEGAL.
+        // H_22 has count=2 in the play (not protected), so play_matches accepts it.
         assert!(
             trick_format.is_legal_play(
                 &hand,
@@ -2997,6 +3017,24 @@ mod tests {
                 bp,
             ),
             "playing 2 pairs + 2 singles should be legal"
+        );
+
+        // With ONLY a triple (no genuine pair), playing 222+singles is LEGAL.
+        // The triple is protected: hand_can_play returns false for pair requirements,
+        // and the play is trivially legal.
+        let mut hands2 = Hands::new(vec![P2]);
+        hands2
+            .add(P2, vec![H_2, H_2, H_2, H_5, H_6, H_7, H_8, H_9, H_J])
+            .unwrap();
+        let hand2 = hands2.get(P2).unwrap().clone();
+        assert!(
+            trick_format.is_legal_play(
+                &hand2,
+                &[H_2, H_2, H_2, H_5, H_6, H_7],
+                TrickDrawPolicy::LongerTuplesProtected,
+                bp,
+            ),
+            "playing triple + singles should be legal when no genuine pair is available"
         );
     }
 

--- a/mechanics/src/trick.rs
+++ b/mechanics/src/trick.rs
@@ -305,12 +305,45 @@ impl TrickFormat {
             if let TrickDrawPolicy::NoFormatBasedDraw = trick_draw_policy {
                 return true;
             }
-            let available_cards = Card::cards(
-                hand.iter()
-                    .filter(|(c, _)| self.trump.effective_suit(**c) == self.suit),
-            )
-            .copied()
-            .collect::<Vec<_>>();
+
+            // When bombs are enabled and LongerTuplesProtected is active, only actual
+            // bombs (count >= 4) should be shielded from format-following obligations.
+            // Non-bomb tuples like 3-of-a-kind are not bombs and must contribute to
+            // satisfying the format (e.g., a triple must yield a pair when one is needed).
+            // We achieve this by excluding bomb cards from the available-cards set used
+            // for the "can the hand do better?" check, and using NoProtections for the
+            // remaining cards so the check is not artificially suppressed.
+            let (available_cards, hand_check_policy): (Vec<Card>, TrickDrawPolicy) =
+                if bomb_policy.bombs_enabled()
+                    && matches!(
+                        trick_draw_policy,
+                        TrickDrawPolicy::LongerTuplesProtected
+                            | TrickDrawPolicy::LongerTuplesProtectedAndOnlyDrawTractorOnTractor
+                    )
+                {
+                    let bomb_free = Card::cards(
+                        hand.iter().filter(|(c, ct)| {
+                            self.trump.effective_suit(**c) == self.suit && **ct < 4
+                        }),
+                    )
+                    .copied()
+                    .collect::<Vec<_>>();
+                    let policy = match trick_draw_policy {
+                        TrickDrawPolicy::LongerTuplesProtectedAndOnlyDrawTractorOnTractor => {
+                            TrickDrawPolicy::OnlyDrawTractorOnTractor
+                        }
+                        _ => TrickDrawPolicy::NoProtections,
+                    };
+                    (bomb_free, policy)
+                } else {
+                    let cards = Card::cards(
+                        hand.iter()
+                            .filter(|(c, _)| self.trump.effective_suit(**c) == self.suit),
+                    )
+                    .copied()
+                    .collect::<Vec<_>>();
+                    (cards, trick_draw_policy)
+                };
 
             for requirement in self.decomposition(trick_draw_policy) {
                 // If it's a match, we're good!
@@ -329,7 +362,7 @@ impl TrickFormat {
                 let hand_can_play = UnitLike::check_play(
                     OrderedCard::make_map(available_cards.iter().copied(), self.trump),
                     requirement.iter().cloned(),
-                    trick_draw_policy,
+                    hand_check_policy,
                 )
                 .next()
                 .is_some();
@@ -844,7 +877,10 @@ impl Trick {
     fn compute_winner(&self, throw_eval_policy: ThrowEvaluationPolicy) -> Option<PlayerID> {
         let tf = self.trick_format.as_ref()?;
         let mut winner = (0, tf.units.to_vec());
-        let mut winner_is_bomb = false;
+        // The leader's play is a bomb when the trick format is a single bomb unit.
+        // We must track this so that a subsequent lower bomb does not incorrectly
+        // win via the "bomb beats non-bomb" branch.
+        let mut winner_is_bomb = tf.units.len() == 1 && tf.units[0].is_bomb();
 
         for (idx, _pc) in self.played_cards.iter().enumerate().skip(1) {
             let mapping = self.played_card_mappings.get(idx).and_then(|m| m.as_ref());
@@ -853,11 +889,20 @@ impl Trick {
             if this_is_bomb {
                 let mapping = mapping.unwrap();
                 let dominated = if winner_is_bomb {
-                    // Both are bombs: higher rank wins (cmp_effective handles trump > non-trump)
-                    mapping[0]
-                        .first_card()
-                        .cmp_effective(winner.1[0].first_card())
-                        == Ordering::Greater
+                    // Both are bombs: more cards wins; equal size: higher rank wins
+                    // (cmp_effective handles trump > non-trump).
+                    let cur_size = mapping[0].size();
+                    let win_size = winner.1[0].size();
+                    match cur_size.cmp(&win_size) {
+                        Ordering::Greater => true,
+                        Ordering::Less => false,
+                        Ordering::Equal => {
+                            mapping[0]
+                                .first_card()
+                                .cmp_effective(winner.1[0].first_card())
+                                == Ordering::Greater
+                        }
+                    }
                 } else {
                     true // Bomb always beats non-bomb
                 };
@@ -2907,6 +2952,157 @@ mod tests {
             .play_cards(pc!(P4, &mut hands, &[S_3, S_5, S_6, S_7]; bp))
             .unwrap();
 
+        assert_eq!(trick.complete().unwrap().winner, P2);
+    }
+
+    // ---- Bug regression tests ----
+
+    /// Bug: with LongerTuplesProtected and 4-of-a-kind bombs enabled, a 3-of-a-kind
+    /// was incorrectly treated as a protected tuple. A triple is not a bomb and
+    /// should be splittable into a pair when following a pairs-based format.
+    #[test]
+    fn test_longer_tuples_protected_does_not_protect_non_bomb_triple() {
+        let bp = BombPolicy::AllowBombs;
+
+        // Trick format: 3-pair tractor in hearts (H_10-H_10-H_J-H_J-H_Q-H_Q)
+        let trick_format = TrickFormat::from_cards(
+            TRUMP,
+            TractorRequirements::default(),
+            &[H_10, H_10, H_J, H_J, H_Q, H_Q],
+            None,
+        )
+        .unwrap();
+
+        // Player has H_K×2 (pair), H_2×3 (triple, NOT a bomb), H_5/H_6/H_7/H_8 (singles)
+        let mut hands = Hands::new(vec![P2]);
+        hands
+            .add(P2, vec![H_K, H_K, H_2, H_2, H_2, H_5, H_6, H_7, H_8])
+            .unwrap();
+        let hand = hands.get(P2).unwrap().clone();
+
+        // Playing H_2×3 + H_5+H_6+H_7 (= "222 + 3 singles") should be ILLEGAL.
+        // The player has KK (pair) and can form 22 (pair from triple), so they must
+        // play at least 2 pairs (e.g., 22KK + 2 singles).
+        assert!(
+            !trick_format.is_legal_play(
+                &hand,
+                &[H_2, H_2, H_2, H_5, H_6, H_7],
+                TrickDrawPolicy::LongerTuplesProtected,
+                bp,
+            ),
+            "playing 3-of-a-kind + singles should be illegal when 2 pairs are available"
+        );
+
+        // Playing H_2×2 + H_K×2 + H_5+H_6 (= "22KK56", 2 pairs + 2 singles) should be LEGAL.
+        assert!(
+            trick_format.is_legal_play(
+                &hand,
+                &[H_2, H_2, H_K, H_K, H_5, H_6],
+                TrickDrawPolicy::LongerTuplesProtected,
+                bp,
+            ),
+            "playing 2 pairs + 2 singles should be legal"
+        );
+    }
+
+    /// Bug: when the leader plays a bomb, compute_winner didn't track it as a bomb
+    /// (winner_is_bomb started as false). This caused any subsequent bomb, even a
+    /// lower one, to incorrectly win by triggering the "bomb beats non-bomb" branch.
+    #[test]
+    fn test_leader_bomb_not_beaten_by_lower_bomb() {
+        let bp = BombPolicy::AllowBombs;
+        let mut hands = Hands::new(vec![P1, P2, P3, P4]);
+        // P1 leads with a bomb (4 heart jacks)
+        hands.add(P1, vec![H_J, H_J, H_J, H_J]).unwrap();
+        // P2 plays a lower bomb (4 heart 2s)
+        hands.add(P2, vec![H_2, H_2, H_2, H_2]).unwrap();
+        // P3 and P4 are void in hearts; they play clubs filler
+        hands.add(P3, vec![C_5, C_6, C_7, C_8]).unwrap();
+        hands.add(P4, vec![C_5, C_6, C_7, C_8]).unwrap();
+
+        let mut trick = Trick::new(TRUMP, vec![P1, P2, P3, P4], bp);
+        trick
+            .play_cards(pc!(P1, &mut hands, &[H_J, H_J, H_J, H_J]; bp))
+            .unwrap();
+        trick
+            .play_cards(pc!(P2, &mut hands, &[H_2, H_2, H_2, H_2]; bp))
+            .unwrap();
+        trick
+            .play_cards(pc!(P3, &mut hands, &[C_5, C_6, C_7, C_8]; bp))
+            .unwrap();
+        trick
+            .play_cards(pc!(P4, &mut hands, &[C_5, C_6, C_7, C_8]; bp))
+            .unwrap();
+
+        // P1 should win: their bomb (4 jacks) outranks P2's bomb (4 twos)
+        assert_eq!(trick.complete().unwrap().winner, P1);
+    }
+
+    /// Complementary check: a higher bomb played after the leader's bomb should win.
+    #[test]
+    fn test_higher_bomb_beats_leader_bomb() {
+        let bp = BombPolicy::AllowBombs;
+        let mut hands = Hands::new(vec![P1, P2, P3, P4]);
+        // P1 leads with a lower bomb (4 heart 2s)
+        hands.add(P1, vec![H_2, H_2, H_2, H_2]).unwrap();
+        // P2 plays a higher bomb (4 heart jacks)
+        hands.add(P2, vec![H_J, H_J, H_J, H_J]).unwrap();
+        // P3 and P4 play clubs filler (void in hearts)
+        hands.add(P3, vec![C_5, C_6, C_7, C_8]).unwrap();
+        hands.add(P4, vec![C_5, C_6, C_7, C_8]).unwrap();
+
+        let mut trick = Trick::new(TRUMP, vec![P1, P2, P3, P4], bp);
+        trick
+            .play_cards(pc!(P1, &mut hands, &[H_2, H_2, H_2, H_2]; bp))
+            .unwrap();
+        trick
+            .play_cards(pc!(P2, &mut hands, &[H_J, H_J, H_J, H_J]; bp))
+            .unwrap();
+        trick
+            .play_cards(pc!(P3, &mut hands, &[C_5, C_6, C_7, C_8]; bp))
+            .unwrap();
+        trick
+            .play_cards(pc!(P4, &mut hands, &[C_5, C_6, C_7, C_8]; bp))
+            .unwrap();
+
+        // P2 wins: their bomb (4 jacks) outranks P1's bomb (4 twos)
+        assert_eq!(trick.complete().unwrap().winner, P2);
+    }
+
+    /// When the leader plays a larger bomb, a smaller same-suit bomb should not win.
+    #[test]
+    fn test_larger_bomb_beats_smaller_bomb_regardless_of_order() {
+        let bp = BombPolicy::AllowBombs;
+        let mut hands = Hands::new(vec![P1, P2, P3, P4]);
+        // P1 leads with a 6-card bomb (6 heart 2s)
+        hands
+            .add(P1, vec![H_2, H_2, H_2, H_2, H_2, H_2])
+            .unwrap();
+        // P2 plays a 6-card bomb of higher rank (6 heart jacks)
+        hands
+            .add(P2, vec![H_J, H_J, H_J, H_J, H_J, H_J])
+            .unwrap();
+        // P3 plays a lower-rank 6-card bomb (6 heart 3s) after P2's win
+        hands
+            .add(P3, vec![H_3, H_3, H_3, H_3, H_3, H_3])
+            .unwrap();
+        hands.add(P4, vec![C_5, C_6, C_7, C_8, C_9, C_10]).unwrap();
+
+        let mut trick = Trick::new(TRUMP, vec![P1, P2, P3, P4], bp);
+        trick
+            .play_cards(pc!(P1, &mut hands, &[H_2, H_2, H_2, H_2, H_2, H_2]; bp))
+            .unwrap();
+        trick
+            .play_cards(pc!(P2, &mut hands, &[H_J, H_J, H_J, H_J, H_J, H_J]; bp))
+            .unwrap();
+        trick
+            .play_cards(pc!(P3, &mut hands, &[H_3, H_3, H_3, H_3, H_3, H_3]; bp))
+            .unwrap();
+        trick
+            .play_cards(pc!(P4, &mut hands, &[C_5, C_6, C_7, C_8, C_9, C_10]; bp))
+            .unwrap();
+
+        // P2 wins: their bomb (6 jacks) outranks both P1's (6 twos) and P3's (6 threes)
         assert_eq!(trick.complete().unwrap().winner, P2);
     }
 }


### PR DESCRIPTION
## Summary

Two bugs in trick validation and winner determination:

1. **Longer-tuple bypass bug**: Under `LongerTuplesProtected`, a longer tuple (e.g. a triple) could satisfy a shorter slot (e.g. a pair) via `NoProtections` decomposition, short-circuiting before the hand check could detect that genuine shorter tuples were available. The player is permitted to use longer tuples in shorter slots, but is not *required* to — so if genuine shorter tuples exist in hand, those must be played instead.

2. **Leader bomb tracking bug**: When the leader plays a bomb, `compute_winner` failed to record it as a bomb, causing any subsequent bomb to incorrectly win via the "bomb beats non-bomb" logic.

## Key Changes

### Longer-tuple bypass fix (`TrickFormat::is_legal_play`)

Added a per-requirement guard inside the decomposition loop. When `play_matches` fires using `NoProtections`, for each simple N-slot (N ≥ 2) in the requirement:

1. Compute how many N-slots are already covered by play cards with `play_ct == N` (legitimately filled).
2. For the remaining slots, call `check_play(available_cards, [N] * remaining, trick_draw_policy)` — the protection-aware check.
3. If the hand can fill those remaining slots, the play is invalid: the player had genuine shorter tuples available and is not required to break a longer tuple.

Using `check_play` (rather than a manual card count) ensures consistent protection semantics: a longer tuple in hand cannot be forced into a shorter slot, so it won't count toward the remaining-slot check.

### Bomb winner determination fix (`Trick::_defeats` and `compute_winner`)

- Extracted bomb comparison logic into `_defeats`: non-bomb always loses to bomb; bomb vs bomb — larger size wins, ties broken by rank.
- Simplified `compute_winner` to use `_defeats` consistently, removing the `winner_is_bomb` flag that wasn't updated when the leader played a bomb.

### Test coverage

- `test_triple_in_play_does_not_satisfy_pair_when_genuine_pair_available`: longer-tuple bypass scenarios across bomb policies
- `test_longer_tuple_guard_requires_enough_genuine_tuples`: verifies the "enough cards" semantics (e.g. 9998876 may play 8876 for KKAA; 9998866 must play 8866 or 9988)
- `test_leader_bomb_not_beaten_by_lower_bomb`: leader bomb not beaten by lower-ranked bomb
- `test_higher_bomb_beats_leader_bomb`: higher-ranked bomb still wins
- `test_larger_bomb_beats_smaller_bomb_regardless_of_order`: bomb size comparison regardless of play order